### PR TITLE
Removed a reference to `--mock` command line flag from docs

### DIFF
--- a/src/views/docs/api/stubs.ejs
+++ b/src/views/docs/api/stubs.ejs
@@ -157,9 +157,7 @@ Transfer-Encoding: chunked
 </code></pre>
 
 <p>Now let's see the <code>matches</code> elements that mountebank
-has saved for you (remember you have to run <code>mb</code> with the
-<code>--mock</code> command line flag to see the <code>matches</code>
-array):</p>
+has saved for you:</p>
 
 <pre><code data-test-id='example'
            data-test-step='4'


### PR DESCRIPTION
Removed a reference to a command line flag since mock verification is now enabled by default in 0cb617604b.
