### PR TITLE
Passing arguments through cmd script

### DIFF
--- a/scripts/dist/createWindowsZip
+++ b/scripts/dist/createWindowsZip
@@ -27,7 +27,7 @@ wget $URL
 
 cp -r ../mountebank .
 
-echo "node.exe mountebank/bin/mb" > ./mb.cmd
+echo "node.exe mountebank/bin/mb %*" > ./mb.cmd
 
 cd ..
 echo "zipping..."


### PR DESCRIPTION
Currently, arguments are not being passed to mb through
mb.cmd.
