### PR TITLE
Made the dryRunValidator model more maintainable

### DIFF
--- a/functionalTest/api/http/httpStubTest.js
+++ b/functionalTest/api/http/httpStubTest.js
@@ -5,7 +5,7 @@ var assert = require('assert'),
     BaseHttpClient = require('./baseHttpClient'),
     promiseIt = require('../../testHelpers').promiseIt,
     port = api.port + 1,
-    timeout = parseInt(process.env.SLOW_TEST_TIMEOUT_MS || 2000),
+    timeout = parseInt(process.env.SLOW_TEST_TIMEOUT_MS || 3000),
     helpers = require('../../../src/util/helpers');
 
 ['http', 'https'].forEach(function (protocol) {

--- a/src/models/dryRunValidator.js
+++ b/src/models/dryRunValidator.js
@@ -9,13 +9,6 @@ var utils = require('util'),
 
 function create (options) {
 
-    function getFirstResponse (stub) {
-        if (stub.responses && stub.responses.length > 0) {
-            return stub.responses[0];
-        }
-        return {};
-    }
-
     function dryRun (stub, encoding, logger) {
         var dryRunProxy = { to: function () { return Q({}); } },
             dryRunLogger = {
@@ -31,9 +24,6 @@ function create (options) {
 
         if (hasInjection(stub)) {
             logger.warn('dry running injection...');
-        }
-        if (getFirstResponse(clone)._behaviors && getFirstResponse(clone)._behaviors.wait) {
-            getFirstResponse(clone)._behaviors.wait = 0;
         }
 
         stubRepository.addStub(clone);


### PR DESCRIPTION
While working on #14, I came across some test-specific code in _dryRunValidator.js_ model. 

These lines of code, AFAICT, are there to avoid potential timeouts in _httpStubTest.js_ – which has a default timeout of 2 seconds.

> The tests in _httpStubTest.js_ require ~2.5 seconds due to the (http and https) exercises of the Wait behavior with 1 second delay each.

The proposed changes in this Pull Request remove the test-specific code by increasing the timeout by 1 second.
