### PR TITLE
Attach logger to Console only when in terminal mode.

### DIFF
--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -36,7 +36,9 @@ function create (options) {
         validateImposterExists = middleware.createImposterValidator(imposters);
 
     logger.remove(logger.transports.Console);
-    logger.add(logger.transports.Console, { colorize: true, level: options.loglevel });
+    if (process.stdout.isTTY) {
+      logger.add(logger.transports.Console, { colorize: true, level: options.loglevel });
+    }
     logger.add(logger.transports.File, {
         filename: options.logfile,
         timestamp: true,


### PR DESCRIPTION
If _mb_ is started in background Console logging should be disabled.
If not whole _mb_ could hang when kernel buffer is full. 
Use case and problem description could be found in [gist: Starting MounteBank from Gradle task ](https://gist.github.com/zedar/66a38d9548b7eeb0a491).
