### PR TITLE
Fix Internal Server Error (500) if predicate attributes have null value.

### DIFF
--- a/src/models/predicates.js
+++ b/src/models/predicates.js
@@ -32,6 +32,9 @@ function normalize (obj, config, encoding) {
         encodeTransform = encoding === 'base64' ? encode : combinators.identity,
         transform = combinators.compose(exceptTransform, caseTransform, encodeTransform),
         transformAll = function (o) {
+            if (!o) {
+              return o;
+            }
             return Object.keys(o).reduce(function (result, key) {
                 var value = o[key];
                 if (typeof o[key] === 'object') {
@@ -49,6 +52,9 @@ function normalize (obj, config, encoding) {
 }
 
 function predicateSatisfied (expected, actual, predicate) {
+    if (!actual) {
+      return false;
+    }
     return Object.keys(expected).every(function (fieldName) {
         if (typeof expected[fieldName] === 'object') {
             return predicateSatisfied(expected[fieldName], actual[fieldName], predicate);


### PR DESCRIPTION
After upgrading to node v.0.11.14, attributes passed to predicate
operators could have null values. In that case, NullPointerException is
thrown and HTTP error 500 is returned.

Test cases:
- _query_ attribute is missing in HTTP call, while it is expected in predicate:
  
  curl -X DELETE http://localhost:4545/customer
  
  "equals": {
    "method": "DELETE",
    "path": "/customer",
    "query": {
      "id": "1001"
    }
  }
- _query_ attribute is not expected in predicate and is not provided in HTTP call:
  
  curl -X PUT -d@data.json http://localhost:4545/customer
  
  "equals": {
    "method": "PUT",
    "path": "/customer"
  }
