### PR TITLE
Enable CORS requests so that Javascript run in browsers can set up imposters

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -26,6 +26,7 @@ function usage () {
     console.log('    --keyfile         file to read for https key (defaults to internal key)');
     console.log('    --certfile        file to read for https cert (defaults to self-signed cert)');
     console.log('    --version         show the mountebank version and exit');
+    console.log('    --allowCORS       allow Cross-Origin Site Requests to mountebank server');
 }
 
 function error (message) {
@@ -159,7 +160,7 @@ try {
             keyfile: '',
             certfile: ''
         },
-        booleanOptions = ['allowInjection', 'nomock', 'heroku', 'version'],
+        booleanOptions = ['allowInjection', 'nomock', 'heroku', 'version', 'allowCORS'],
         commandLine = cli.parse(process.argv.slice(2), defaultOptions, booleanOptions),
         server = serverAt(commandLine.options);
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "simplesmtp": "~0.3.16",
     "soap": "^0.8.0",
     "winston": "~1.0.0",
-    "xml2js": "^0.4.4"
+    "xml2js": "^0.4.4",
+    "cors": "~2.5.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -61,7 +61,9 @@ function create (options) {
     app.use(express.static(path.join(__dirname, 'public')));
     app.use(express.static(path.join(__dirname, '../node_modules')));
     app.use(errorHandler());
-    app.use(cors());
+    if(options.allowCORS) {
+        app.use(cors());
+    }
 
     app.disable('etag');
     app.disable('x-powered-by');

--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var express = require('express'),
+    cors = require('cors'),
     errorHandler = require('errorhandler'),
     path = require('path'),
     middleware = require('./util/middleware'),
@@ -60,6 +61,7 @@ function create (options) {
     app.use(express.static(path.join(__dirname, 'public')));
     app.use(express.static(path.join(__dirname, '../node_modules')));
     app.use(errorHandler());
+    app.use(cors());
 
     app.disable('etag');
     app.disable('x-powered-by');

--- a/src/views/docs/commandLine.ejs
+++ b/src/views/docs/commandLine.ejs
@@ -57,8 +57,8 @@ description = 'Command line parameters for starting mountebank'
     <td><code>--allowCORS</code></td>
     <td>Permits Cross-Origin Site Requests by adding the appropriate HTTP response headers. This can
       be useful if you're working with mountebank via browser-based AJAX requests. Note that this 
-      does not add the CORS headers to any imposters you create. You'll need to add those during
-      imposter creation.
+      does not add the CORS headers to any imposters you create. You'll need to add those to the
+      imposter itself.
     <td><code>false</code></td>
   </tr>
   <tr>

--- a/src/views/docs/commandLine.ejs
+++ b/src/views/docs/commandLine.ejs
@@ -54,6 +54,14 @@ description = 'Command line parameters for starting mountebank'
     <td><code>false</code></td>
   </tr>
   <tr>
+    <td><code>--allowCORS</code></td>
+    <td>Permits Cross-Origin Site Requests by adding the appropriate HTTP response headers. This can
+      be useful if you're working with mountebank via browser-based AJAX requests. Note that this 
+      does not add the CORS headers to any imposters you create. You'll need to add those during
+      imposter creation.
+    <td><code>false</code></td>
+  </tr>
+  <tr>
     <td><code>--nomock</code></td>
     <td>mountebank supports mock verification and stub debugging by remembering the requests
       made against each stub.  See the <a href='/docs/api/mocks'>mocks</a> page for more details.


### PR DESCRIPTION
It'd be great for me to be able to set up mountebank imposters from within some browser-based tests. Unfortunately, due to the Same-Origin policy, a browser test by default cannot connect back to anything except the same domain & port that it was served from.

By enabling CORS in the Express server, mb is able to accept the full suite of HTTP methods from Browser AJAX calls, no matter where the request originated from. That way the browser tests can set up their own stubs.

This unfortunately does not extend to the imposter servers that are spun up by mb. For those, the tester would currently need to set the X-Origin headers in the imposters themselves. But this is manageable for me for now.