### PR TITLE
Allow ie to receive json if explicitly requested

### DIFF
--- a/src/util/middleware.js
+++ b/src/util/middleware.js
@@ -103,7 +103,9 @@ function defaultIEtoHTML (request, response, next) {
     // IE has inconsistent Accept headers, often defaulting to */*
     // Our default is JSON, which fails to render in the browser on content-negotiated pages
     if (request.headers['user-agent'] && request.headers['user-agent'].indexOf('MSIE') >= 0) {
-        request.headers.accept = 'text/html';
+        if ( !(request.headers['accept'] && request.headers.accept.match(/application\/json/)) ) {
+            request.headers.accept = 'text/html';
+        }
     }
     next();
 }

--- a/test/util/middlewareTest.js
+++ b/test/util/middlewareTest.js
@@ -236,5 +236,14 @@ describe('middleware', function () {
 
             assert.strictEqual(request.headers.accept, 'text/html');
         });
+
+        it('should not change accept header for IE user agents if application/json explicitly included', function () {
+            request.headers['user-agent'] = 'blah MSIE blah';
+            request.headers.accept = 'accept/any, application/json';
+
+            middleware.defaultIEtoHTML(request, response, next);
+
+            assert.strictEqual(request.headers.accept, 'accept/any, application/json');
+        });
     });
 });


### PR DESCRIPTION
Sometimes I want to make an AJAX request from IE to a mountebank server, and I am served text/html, even when I set the accepts header explicitly to application/json. This patch allows for application/json if it is explicitly requested.