### PR TITLE
allow setting up imposters via option

### DIFF
--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -45,7 +45,7 @@ function initializeLogfile (filename) {
 function create (options) {
     var deferred = Q.defer(),
         app = express(),
-        imposters = {},
+        imposters = options.imposters || {},
         protocols = {
             tcp: require('./models/tcp/tcpServer').initialize(options.allowInjection, options.mock, options.debug),
             http: require('./models/http/httpServer').initialize(options.allowInjection, options.mock, options.debug),


### PR DESCRIPTION
This allows imposters being created up-front rather than through the HTTP interface, e.g. when using mountebank in tests locally.