### PR TITLE
Support multiple response cookies with the same name

### DIFF
--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -79,10 +79,20 @@ function create (logger) {
         });
     }
 
+    function add (current, value) {
+        return Array.isArray(current) ? current.concat(value) : [current].concat(value);
+    }
+
+    function arrayifyIfExists (current, value) {
+        return current ? add(current, value) : value;
+    }
+
     function headersFor (rawHeaders) {
         var result = {};
         for (var i = 0; i < rawHeaders.length; i += 2) {
-            result[rawHeaders[i]] = rawHeaders[i + 1];
+            var name = rawHeaders[i];
+            var value = rawHeaders[i + 1];
+            result[name] = arrayifyIfExists(result[name], value);
         }
         return result;
     }


### PR DESCRIPTION
I've made a patch that will create an array of response headers if more than one is found. Otherwise it behaves as it did before. Re #137 my output from curl is now.

```
❯ curl -ik https://localhost:9002/ws-api/v1/client/session
HTTP/1.1 200 OK
Server: nginx
Content-Type: application/json;charset=UTF-8
Content-Length: 115
Date: Wed, 20 Apr 2016 05:57:16 GMT
Connection: close
Set-Cookie: JSESSIONID= 86752943865765SDSDFSD.APP4P; Path=/; Secure; HttpOnly
Set-Cookie: JSESSIONID= 86752943865765SDSDFSD.APP4P; Path=/; HttpOnly
Set-Cookie: akavpau_prodvp=1461132136~id= 485273495872645634re23467; path=/
Access-Control-Allow-Origin: https://localhost:8010
```