### PR TITLE
Fix url.parse().query hasOwnProperty bug

### DIFF
--- a/src/controllers/imposterController.js
+++ b/src/controllers/imposterController.js
@@ -16,7 +16,7 @@ var url = require('url'),
 function create (imposters) {
 
     function queryBoolean (query, key) {
-        if (!query.hasOwnProperty(key)) {
+        if (query[key] === undefined) {
             return false;
         }
         return query[key].toLowerCase() === 'true';

--- a/src/controllers/impostersController.js
+++ b/src/controllers/impostersController.js
@@ -21,14 +21,14 @@ var Q = require('q'),
 function create (protocols, imposters, Imposter, logger) {
 
     function queryIsFalse (query, key) {
-        if (!query.hasOwnProperty(key)) {
+        if (query[key] === undefined) {
             return true;
         }
         return query[key].toLowerCase() !== 'false';
     }
 
     function queryBoolean (query, key) {
-        if (!query.hasOwnProperty(key)) {
+        if (query[key] === undefined) {
             return false;
         }
         return query[key].toLowerCase() === 'true';


### PR DESCRIPTION
querystring no longer inherits from Object, therefore it no longer has
hasOwnProperty method.

this commit fixes issue #144 