### PR TITLE
Issue #130 - Support a response executing only N times

### DIFF
--- a/src/models/repeatBehavior.js
+++ b/src/models/repeatBehavior.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Executes the repeat behavior for a stub.
+ * @module
+ */
+
+
+/**
+ * Creates an instance of RepeatBehavior
+ *
+ * Repeat Behavior is stateful, so a new instance must be created
+ * for each request.
+ * @returns {{execute: execute}}
+ */
+function create () {
+    var repeats = {};
+
+    function getNextResponse (stub, traversed) {
+        var response = stub.responses.shift();
+
+        if (response._behaviors && response._behaviors.repeat) {
+            var key = JSON.stringify(response);
+
+            if (traversed[key]) {
+                stub.responses.push(response);
+                response = { is: {} };
+            }
+            else {
+                traversed[key] = response;
+
+                if (!repeats[key]) {
+                    repeats[key] = 0;
+                }
+
+                if (repeats[key] < response._behaviors.repeat) {
+                    repeats[key] += 1;
+
+                    stub.responses.unshift(response);
+                }
+                else {
+                    stub.responses.push(response);
+                    response = getNextResponse(stub, traversed);
+                }
+            }
+        }
+        else {
+            stub.responses.push(response);
+        }
+
+        return response;
+    }
+
+    /**
+     * Executes the repeat behavior of a stub.  It either returns the next response
+     * or returns the default response if all repeats have been exhausted.
+     * @param {Object} stub - The stub to execute repeat behavior on
+     * @returns {Object} The response
+     */
+    function execute (stub) {
+        return getNextResponse(stub, {});
+    }
+
+    return {
+        execute: execute
+    };
+}
+
+
+module.exports = {
+    create: create
+};

--- a/src/models/stubRepository.js
+++ b/src/models/stubRepository.js
@@ -6,6 +6,7 @@
  */
 
 var predicates = require('./predicates'),
+    RepeatBehavior = require('./repeatBehavior'),
     Q = require('q');
 
 /**
@@ -22,6 +23,7 @@ function create (resolver, recordMatches, encoding) {
      * @type {Array}
      */
     var stubs = [];
+    var repeatBehavior = RepeatBehavior.create();
 
     function trueForAll (list, predicate) {
         // we call map before calling every so we make sure to call every
@@ -67,12 +69,10 @@ function create (resolver, recordMatches, encoding) {
      */
     function resolve (request, logger) {
         var stub = findFirstMatch(request, logger) || { responses: [{ is: {} }] },
-            responseConfig = stub.responses.shift(),
+            responseConfig = repeatBehavior.execute(stub),
             deferred = Q.defer();
 
         logger.debug('generating response from ' + JSON.stringify(responseConfig));
-
-        stub.responses.push(responseConfig);
 
         resolver.resolve(responseConfig, request, logger, stubs).done(function (response) {
             var match = {

--- a/src/views/docs/api/behaviors.ejs
+++ b/src/views/docs/api/behaviors.ejs
@@ -30,6 +30,12 @@ the following behaviors</p>
       can take up to three values: the request, the response, and a logger.  You can either mutate the
       response passed in (and return nothing), or return an altogether new response.</td>
   </tr>
+    <tr>
+        <td><code>repeat</code></td>
+        <td>Repeat a response only a set number of times.  When this is set, Mountebank will not cycle
+            through multiple responses as normal and instead will return this response until the number of repeats has
+            been exhausted.</td>
+    </tr>
 </table>
 
 <p>Multiple behaviors can be added to a response.  However, only one of each type of behavior
@@ -47,13 +53,20 @@ can exist on a single response.</p>
       <% include behaviors/wait %>
     </section>
   </div>
-  <div>
-    <input id='behavior-decorate' name='behavior-decorate' type="checkbox" />
-    <label for='behavior-decorate'>decorate</label>
-    <section>
-      <% include behaviors/decorate %>
-    </section>
-  </div>
+    <div>
+        <input id='behavior-decorate' name='behavior-decorate' type="checkbox" />
+        <label for='behavior-decorate'>decorate</label>
+        <section>
+            <% include behaviors/decorate %>
+        </section>
+    </div>
+    <div>
+        <input id='behavior-repeat' name='behavior-repeat' type="checkbox" />
+        <label for='behavior-repeat'>repeat</label>
+        <section>
+            <% include behaviors/repeat %>
+        </section>
+    </div>
 </section>
 
 <% include ../../_footer %>

--- a/src/views/docs/api/behaviors/repeat.ejs
+++ b/src/views/docs/api/behaviors/repeat.ejs
@@ -101,6 +101,6 @@ Then this will start responding
     Host: localhost:<%= port %>
 </code>
 
-<p>Mountebank keeps track internally of how many times each response has been returned.  Typically
-    this means that the last response should not have a repeat defined.  If all requests have repeats
-    defined, then Mountebank will return the default response thereafter.</p>
+<p>Mountebank keeps track internally of how many times each response has been returned.  Responses without
+    repeats will return indefinitely.  If all requests have repeats defined, then Mountebank will return
+    the default response after all repeats are exhausted.</p>

--- a/src/views/docs/api/behaviors/repeat.ejs
+++ b/src/views/docs/api/behaviors/repeat.ejs
@@ -1,0 +1,106 @@
+<p>The <code>repeat</code> behavior allows certain responses to only return a certain number of times.
+    In the below example, the first response is configured to return 2 times, then all subsequent requests
+    return the second response:</p>
+
+<pre><code data-test-id='repeat'
+           data-test-step='1'
+           data-test-type='http'>
+POST /imposters HTTP/1.1
+Host: localhost:<%= port %>
+Accept: application/json
+Content-Type: application/json
+
+{
+  "port": 7777,
+  "protocol": "http",
+  "stubs": [
+    {
+      "responses": [
+        {
+          "is": {
+            "body": "This will only repeat 2 times"
+          },
+          "_behaviors": {
+            "repeat": 2
+          }
+        },
+        {
+          "is": {
+            "body": "Then this will start responding"
+          }
+        }
+      ]
+    }
+  ]
+}
+</code></pre>
+
+<p>Now the first response will return 2 times, then every call thereafter will return the second response.</p>
+
+<pre><code data-test-id='repeat'
+           data-test-step='2'
+           data-test-type='http'>
+GET / HTTP/1.1
+Host: localhost:7777
+</code></pre>
+
+<pre><code data-test-id='repeat'
+           data-test-verify-step='2'
+           data-test-ignore-lines='["^Date"]'>
+HTTP/1.1 200 OK
+Date: Thu, 01 Jan 2015 02:30:31 GMT
+Connection: close
+Transfer-Encoding: chunked
+
+This will only repeat 2 times
+</code></pre>
+
+
+<pre><code data-test-id='repeat'
+           data-test-step='3'
+           data-test-type='http'>
+GET / HTTP/1.1
+Host: localhost:7777
+</code></pre>
+
+<pre><code data-test-id='repeat'
+           data-test-verify-step='3'
+           data-test-ignore-lines='["^Date"]'>
+HTTP/1.1 200 OK
+Date: Thu, 01 Jan 2015 02:30:31 GMT
+Connection: close
+Transfer-Encoding: chunked
+
+This will only repeat 2 times
+</code></pre>
+
+
+<pre><code data-test-id='repeat'
+           data-test-step='4'
+           data-test-type='http'>
+GET / HTTP/1.1
+Host: localhost:7777
+</code></pre>
+
+<pre><code data-test-id='repeat'
+           data-test-verify-step='4'
+           data-test-ignore-lines='["^Date"]'>
+HTTP/1.1 200 OK
+Date: Thu, 01 Jan 2015 02:30:31 GMT
+Connection: close
+Transfer-Encoding: chunked
+
+Then this will start responding
+</code></pre>
+
+
+<code class='hidden' data-test-id='repeat'
+      data-test-step='5'
+      data-test-type='http'>
+    DELETE /imposters/5555 HTTP/1.1
+    Host: localhost:<%= port %>
+</code>
+
+<p>Mountebank keeps track internally of how many times each response has been returned.  Typically
+    this means that the last response should not have a repeat defined.  If all requests have repeats
+    defined, then Mountebank will return the default response thereafter.</p>


### PR DESCRIPTION
Implemented feature requested in Issue #130.  When a repeat behavior is added, it basically overrides the existing 'cycling' for multiple responses that Mountebank currently does.  So Mountebank will basically go down the list of responses until each repeat has been 'exhausted'.  In terms of implementation I broke repeat out into its own module because it was significantly different than the other behaviors (executes at a different point in the request lifecycle and it is stateful by design).  I'm a little unhappy with the cycle detection logic I had to implement, so I'm open to suggestions on that (basically stringifying responses and using them as keys in an object to detect infinite loops).

Please let me know any thoughts. Thanks!