### PR TITLE
Inject headers into outgoing proxied requests

### DIFF
--- a/src/models/responseResolver.js
+++ b/src/models/responseResolver.js
@@ -134,6 +134,12 @@ function create (proxy, postProcess) {
     }
 
     function proxyAndRecord (responseConfig, request, logger, stubs) {
+        if (responseConfig.proxy && responseConfig.proxy.injectHeaders) {
+            for (var key in responseConfig.proxy.injectHeaders) {
+                request.headers[key] = responseConfig.proxy.injectHeaders[key];
+            }
+        }
+
         return proxy.to(responseConfig.proxy.to, request, responseConfig.proxy).then(function (response) {
             if (!shouldDecorate(request, responseConfig)) {
                 return Q(response);

--- a/src/views/docs/api/proxies.ejs
+++ b/src/views/docs/api/proxies.ejs
@@ -49,6 +49,14 @@ filled in.</p>
     <td>array</td>
     <td>An array of objects that defines how the predicates for new stubs are created.</td>
   </tr>
+  <tr>
+    <td><code>injectHeaders</code></td>
+    <td><code>{}</code></td>
+    <td>object</td>
+    <td>Key-value pairs of headers to inject into the proxied <i>request</i>.  This is useful when the behavior of
+    the system being proxied can be altered with appropriate headers (e.g. pointing REST links back to Mountebank
+    for further proxying).  Existing headers will be overwritten if they match the injected headers.</td>
+  </tr>
 </table>
 
 <p>http and https proxies add two additional optional parameters for situations where the
@@ -269,6 +277,13 @@ Content-Type: application/json
     <label for='proxy-always'>proxyAlways</label>
     <section>
       <% include proxy/proxyAlways %>
+    </section>
+  </div>
+  <div>
+    <input id='proxy-inject-headers' name='proxy-inject-headers' type="checkbox" />
+    <label for='proxy-inject-headers'>injectHeaders</label>
+    <section>
+      <% include proxy/injectHeaders %>
     </section>
   </div>
 </section>

--- a/src/views/docs/api/proxy/injectHeaders.ejs
+++ b/src/views/docs/api/proxy/injectHeaders.ejs
@@ -30,7 +30,7 @@ Content-Type: application/json
 }
 </code></pre>
 
-<p>Now, let's set up another imposter that will proxy requests to that mirror imposter.  We'll also set up the inject
+<p>Now, let's set up another imposter that will proxy requests to the mirror imposter.  We'll also set up the inject
 headers field to insert some custom headers in the outgoing request:</p>
 
 <pre><code data-test-id='proxy example'
@@ -88,5 +88,5 @@ Transfer-Encoding: chunked
 The body.
 </code></pre>
 
-<p>Now we can see that the 'X-My-Custom-Header' value was returned back to us, reflected back from the mirror imposter
+<p>Now we can see that the X-My-Custom-Header-One and Two headers were returned back to us, reflected back from the mirror imposter
 after being injected into the <i>outgoing</i> request.</p>

--- a/src/views/docs/api/proxy/injectHeaders.ejs
+++ b/src/views/docs/api/proxy/injectHeaders.ejs
@@ -1,0 +1,92 @@
+<p>First let's create a mirror imposter so we can see what headers are sent.  This imposter just takes the request
+headers it receives and sends them back in the response:</p>
+
+<pre><code data-test-id='proxy example'
+           data-test-step='18'
+           data-test-type='http'>
+POST /imposters HTTP/1.1
+Host: localhost:<%= port %>
+        Accept: application/json
+Content-Type: application/json
+
+{
+  "port": 7002,
+  "protocol": "http",
+  "name": "Mirror",
+  "stubs": [
+    {
+      "responses": [
+        {
+          "is": {
+            "body": "The body."
+          },
+          "_behaviors": {
+            "decorate": "function (req, res) { res.headers = req.headers; }"
+          }
+        }
+      ]
+    }
+  ]
+}
+</code></pre>
+
+<p>Now, let's set up another imposter that will proxy requests to that mirror imposter.  We'll also set up the inject
+headers field to insert some custom headers in the outgoing request:</p>
+
+<pre><code data-test-id='proxy example'
+           data-test-step='19'
+           data-test-type='http'>
+POST /imposters HTTP/1.1
+Host: localhost:<%= port %>
+        Accept: application/json
+Content-Type: application/json
+
+{
+  "port": 7001,
+  "protocol": "http",
+  "name": "Inject Headers",
+  "stubs": [
+    {
+      "responses": [
+        {
+          "proxy": {
+            "to": "http://localhost:7002",
+            "mode": "proxyAlways",
+            "injectHeaders": {
+               "X-My-Custom-Header-One": "my first value",
+               "X-My-Custom-Header-Two": "my second value"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+</code></pre>
+
+<p>Then we send a request to our proxy imposter:</p>
+
+<pre><code data-test-id='proxy example'
+           data-test-step='20'
+           data-test-type='http'>
+GET / HTTP/1.1
+Host: localhost:7001
+</code></pre>
+
+<pre><code data-test-id='proxy example'
+           data-test-verify-step='20'
+           data-test-ignore-lines='["^Date"]'>
+HTTP/1.1 200 OK
+Accept: application/json
+Host: localhost:7002
+Connection: close
+Date: Thu, 09 Jan 2014 02:30:31 GMT
+X-My-Custom-Header-One: my first value
+X-My-Custom-Header-Two: my second value
+Transfer-Encoding: chunked
+
+The body.
+</code></pre>
+
+<p>Now we can see that the 'X-My-Custom-Header' value was returned back to us, reflected back from the mirror imposter
+after being injected into the <i>outgoing</i> request.</p>


### PR DESCRIPTION
Adding the ability to inject headers into outgoing proxied request, as detailed in issue #152.