### PR TITLE
Add http(s)-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "json-stable-stringify": "~1.0.0",
     "jsonpath-plus": "^0.15.0",
     "mailparser": "~0.6.1",
+    "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "1.0.0",
     "q": "~1.4.1",
     "simplesmtp": "~0.3.16",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "json-stable-stringify": "~1.0.0",
     "jsonpath-plus": "^0.15.0",
     "mailparser": "~0.6.1",
+    "https-proxy-agent": "1.0.0",
     "q": "~1.4.1",
     "simplesmtp": "~0.3.16",
     "winston": "~2.3.0",


### PR DESCRIPTION
Hi, I installed `1.7.2` of mountebank and got this complaint in my tests:

    Error: Cannot find module 'https-proxy-agent'

It seems like you `require` this package somewhere in your code, but don't list it in `package.json`. Same goes for `http-proxy-agent`. This PR adds them to your dependencies.