### PR TITLE
Updated imposter.ejs to validate with jsonlint

### DIFF
--- a/src/views/docs/api/contracts/imposter.ejs
+++ b/src/views/docs/api/contracts/imposter.ejs
@@ -26,8 +26,8 @@
 <span id='imposter-stubs-_behaviors'><%- indent(10) %>&quot;_behaviors&quot;: {</span>
 <span id='imposter-stubs-_behaviors-wait'><%- indent(12) %>&quot;wait&quot;: 500,</span>
 <span id='imposter-stubs-_behaviors-repeat'><%- indent(12) %>&quot;repeat&quot;: 3,</span>
-<span id='imposter-stubs-_behaviors-decorate'><%- indent(12) %>&quot;decorate&quot;: &quot;function (request, response) { response.body = response.body.replace('${TIME}', 'now'); }&quot;</span>
-<span id='imposter-stubs-_behaviors-shellTransform'><%- indent(12) %>&quot;shellTransform&quot;: 'transformResponse',</span>
+<span id='imposter-stubs-_behaviors-decorate'><%- indent(12) %>&quot;decorate&quot;: &quot;function (request, response) { response.body = response.body.replace('${TIME}', 'now'); }&quot;,</span>
+<span id='imposter-stubs-_behaviors-shellTransform'><%- indent(12) %>&quot;shellTransform&quot;: &quot;transformResponse&quot;,</span>
 <span id='imposter-stubs-_behaviors-copy'><%- indent(12) %>&quot;copy&quot;: [
                 {
                     "from": { "headers": "If-Modified-Since" },
@@ -72,7 +72,7 @@
                         "path": "values.csv",
                         "keyColumn": "month"
                       }
-                    }
+                    },
                     "into": "${row}"
                 }
             ]</span>
@@ -97,7 +97,7 @@
             ],</span>
 <span id='imposter-stubs-responses-proxy-injectHeaders'><%- indent(12) %>&quot;injectHeaders&quot;: {
                 &quot;X-Custom-Header&quot;: &quot;Served by mountebank&quot;
-            },</span>
+            }</span>
           }
         },
         {


### PR DESCRIPTION
Updates to imposter contract documentation.

While reading the imposter contract documentation, I noticed that copying the contract JSON out to a JSON lint formatter caused the data not to validate correctly.