### PR TITLE
Allow "matches" predicate to compare an array of regex with a request…

### DIFF
--- a/src/models/predicates.js
+++ b/src/models/predicates.js
@@ -172,12 +172,27 @@ function predicateSatisfied (expected, actual, predicate) {
         }
 
         if (Array.isArray(actual[fieldName])) {
-            return actual[fieldName].some(test);
+            if (Array.isArray(expected[fieldName])) {
+                return actual[fieldName].every(test);
+            }
+            else {
+                return actual[fieldName].some(test);
+            }
         }
         else if (!helpers.defined(actual[fieldName]) && Array.isArray(actual)) {
             // support array of objects in JSON
             return actual.some(function (element) {
                 return predicateSatisfied(expected, element, predicate);
+            });
+        }
+        else if (Array.isArray(expected)) {
+            return expected.some(function (expectedValue) {
+                if (typeof expected[fieldName] === 'object') {
+                    return predicateSatisfied(expectedValue, actual, predicate);
+                }
+                else {
+                    return predicate(expectedValue, actual);
+                }
             });
         }
         else if (typeof expected[fieldName] === 'object') {

--- a/test/models/predicates/matchesTest.js
+++ b/test/models/predicates/matchesTest.js
@@ -78,6 +78,30 @@ describe('predicates', function () {
             assert.ok(!predicates.evaluate(predicate, request));
         });
 
+        it('should return true if repeating query key has value matching array', function () {
+            var predicate = { matches: { query: { key: ['^begin', '^middle', 'end$'] } } },
+                request = { query: { key: ['begin', 'middle', 'end'] } };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
+
+        it('should return false if repeating query key does not have value matching array', function () {
+            var predicate = { matches: { query: { key: ['^begin', '^middle', '^nd'] } } },
+                request = { query: { key: ['begin', 'middle', 'end'] } };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+
+        it('should return true if repeating query key has value matching array object', function () {
+            var predicate = { matches: { query: { key: [{ key1: 'value1$' }, { key1: '^value2' }] } } },
+                request = { query: { key: [{ key1: 'value1' }, { key1: 'value2' }] } };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
+
+        it('should return false if repeating query key does not have matching array object', function () {
+            var predicate = { matches: { query: { key: [{ key1: 'value1$' }, { key1: '^value2' }] } } },
+                request = { query: { key: [{ key1: 'value1' }, { key1: '^alue2' }] } };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+
         it('should be case insensitive for object keys by default (issue 169)', function () {
             var predicate = { matches: { headers: { field: 'end$' } } },
                 request = { headers: { FIELD: 'begin middle end' } };


### PR DESCRIPTION
Allow "matches" predicate to compare an array of regex with a request containing an array in the same level of this array of regex.

The need comes from our testing strategy using mountebank proxy feature. As more than 90% of our APIs use Json RPC protocol, the POST parameters can take these form : 

```json
{
  "jsonrpc": "2.0",
  "method": "default:domain.resource.action/1",
  "id": "124567890",
  "params": {
    "_ctx": {
      "tid": "abcdef",
      "principal": "abc-def-ghi"
    },
    "locale": "fr_FR",
    "key1": [
      "value1",
      "value2",
      "vallue3"
    ],
    "key2": "1"
  }
}
```

The best way that we found is, to use "matches" predicate : 
```json
{
  "matches": {
    "body": {
      "jsonrpc": "2\\.0",
      "method": "default\\:domain\\.resource\\.action\/1",
      "id": "[0-9]+",
      "params": {
        "_ctx": {
          "tid": "[0-9a-z]+",
          "principal": "[0-9\\-a-z]+"
        },
        "locale": "fr_FR",
        "key1": [
          "value1",
          "value2",
          "vallue3"
        ],
        "key2": "1"
      }
    }
  }
}
```
Unfortunately, this stub predicate does not match our RPC request. That why I did this PR which allow us to automate stub generation.

Please, feel free to contact me if any question nassim.kirouane@inovia-team.com

Thank you.