### PR TITLE
Require the "imposters" key to be present when calling `PUT /imposters`

### DIFF
--- a/src/controllers/impostersController.js
+++ b/src/controllers/impostersController.js
@@ -191,6 +191,13 @@ function create (protocols, imposters, Imposter, logger) {
 
         logger.debug(requestDetails(request));
 
+        if (!('imposters' in request.body)) {
+            respondWithValidationErrors(response, [
+                exceptions.ValidationError("'imposters' is a required field")
+            ]);
+            return Q(false);
+        }
+
         return Q.all(validationPromises).then(function (validations) {
             var isValid = validations.every(function (validation) {
                 return validation.isValid;
@@ -198,7 +205,7 @@ function create (protocols, imposters, Imposter, logger) {
 
             if (isValid) {
                 return deleteAllImposters().then(function () {
-                    var creationPromises = request.body.imposters.map(function (imposter) {
+                    var creationPromises = requestImposters.map(function (imposter) {
                         return Imposter.create(protocols[imposter.protocol], imposter);
                     });
 

--- a/test/controllers/impostersControllerTest.js
+++ b/test/controllers/impostersControllerTest.js
@@ -285,12 +285,35 @@ describe('ImpostersController', function () {
             };
         });
 
+        promiseIt('should return a 400 if the "imposters" key is not present', function () {
+            var existingImposter = { stop: mock() },
+                imposters = { 0: existingImposter },
+                controller = Controller.create({ http: Protocol }, imposters, {}, logger);
+
+            request.body = {};
+
+            return controller.put(request, response).then(function () {
+                assert.strictEqual(response.statusCode, 400);
+                assert.deepEqual(response.body, {
+                    errors: [{
+                        code: 'bad data',
+                        message: "'imposters' is a required field"
+                    }]
+                });
+
+                assert.deepEqual(imposters, { 0: existingImposter });
+            });
+        });
+
         promiseIt('should return an empty array if no imposters provided', function () {
-            var controller = Controller.create({ http: Protocol }, {}, {}, logger);
+            var existingImposter = { stop: mock() },
+                imposters = { 0: existingImposter },
+                controller = Controller.create({ http: Protocol }, imposters, {}, logger);
             request.body = { imposters: [] };
 
             return controller.put(request, response).then(function () {
                 assert.deepEqual(response.body, { imposters: [] });
+                assert.deepEqual(imposters, {});
             });
         });
 


### PR DESCRIPTION
The goal is to fix a bug where specifying an empty JSON body when calling `PUT /imposters` would return `400` and delete all imposters.

With this change, there is added validation that ensures that the `imposters` key is included in the request. If it is not, it return a useful error message and `400` without deleting the imposters.

There was one remaining question in my head: what should happen if the JSON body includes the `imposters` key but the value is falsy?

e.g.

```json
{
    "imposters": null
}
```

The current behaviour is that such queries are considered as being the same as passing an empty array. Should this stay as is or should it require that the value be an array?

Fixes #246