### PR TITLE
New API DELETE /imposters/:id/requests, applicable only for proxied stubs

### DIFF
--- a/src/controllers/imposterController.js
+++ b/src/controllers/imposterController.js
@@ -45,6 +45,36 @@ function create (imposters) {
         });
     }
 
+    function deleteRequests(request, response) {
+        var Q = require('q'),
+        imposter = imposters[request.params.id],
+        json = {},
+        url = require('url'),
+        query = url.parse(request.url, true).query,
+        options = { replayable: false, removeProxies: false };
+        
+        if (imposter) {
+            imposter.deleteRequests();
+            imposter = imposter.toJSON(options);
+            
+            response.format({
+                json: function () { response.send(imposter); },
+                html: function () {
+                    if (request.headers['x-requested-with']) {
+                        response.render('_imposter', { imposter: imposter });
+                    }
+                    else {
+                        response.render('imposter', { imposter: imposter });
+                    }
+                }
+            });
+            return Q(true);
+        }
+        else {
+            response.send(json);
+            return Q(true);
+        }
+    }
     /**
      * The function responding to DELETE /imposters/:port
      * @memberOf module:controllers/imposterController#
@@ -75,7 +105,8 @@ function create (imposters) {
 
     return {
         get: get,
-        del: del
+        del: del,
+        deleteRequests: deleteRequests
     };
 }
 

--- a/src/models/abstractServer.js
+++ b/src/models/abstractServer.js
@@ -127,6 +127,10 @@ function implement (implementation, recordRequests, debug, baseLogger) {
                 stubs: server.stubs,
                 metadata: metadata,
                 port: actualPort,
+                deleteRequests: function() {
+                    numRequests = 0;
+                    server.deleteRequests();
+                },
                 close: function () {
                     var closeDeferred = Q.defer();
                     server.close(function () {

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -103,7 +103,8 @@ function setup (protocolName, createBaseServer) {
                 metadata: baseServer.metadata,
                 addStub: stubs.addStub,
                 state: {},
-                stubs: stubs.stubs
+                stubs: stubs.stubs,
+                deleteRequests: stubs.deleteRequests
             }),
             server = baseServer.createNodeServer();
 

--- a/src/models/imposter.js
+++ b/src/models/imposter.js
@@ -115,12 +115,17 @@ function create (Protocol, request) {
                 return result;
             }
 
+            function deleteRequests() {
+                server.deleteRequests();
+            }
+
             deferred.resolve({
                 port: server.port,
                 url: url,
                 toJSON: toJSON,
                 addStub: server.addStub,
-                stop: server.close
+                stop: server.close,
+                deleteRequests: deleteRequests
             });
         });
     });

--- a/src/models/stubRepository.js
+++ b/src/models/stubRepository.js
@@ -104,6 +104,21 @@ function create (resolver, recordMatches, encoding) {
     }
 
     /**
+     * Deletes the proxy request and responses for this imposter
+     * Brings the imposter back to "newly created state" i.e.
+     * num_requests = 0.
+     * 
+     * Does not touch the stubbed requests.
+     */
+    function deleteRequests() {
+    
+        // TODO: should this delegate to resolver?
+        if(stubs[0] && stubs[0].responses[0].proxy) {
+            stubs.splice(1);
+        }
+    }
+
+    /**
      * Finds the right stub for a request and generates a response
      * @memberOf module:models/stubRepository#
      * @param {Object} request - The protocol request
@@ -136,7 +151,8 @@ function create (resolver, recordMatches, encoding) {
     return {
         stubs: getStubs,
         addStub: addStub,
-        resolve: resolve
+        resolve: resolve,
+        deleteRequests: deleteRequests
     };
 }
 

--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -103,6 +103,8 @@ function create (options) {
     app.put('/imposters', impostersController.put);
     app.get('/imposters/:id', validateImposterExists, imposterController.get);
     app.delete('/imposters/:id', imposterController.del);
+    app.delete('/imposters/:id/requests', imposterController.deleteRequests);
+    
     app.get('/logs', logsController.get);
     app.get('/config', configController.get);
     app.get('/feed', feedController.getFeed);

--- a/test/controllers/imposterControllerTest.js
+++ b/test/controllers/imposterControllerTest.js
@@ -170,5 +170,19 @@ describe('ImposterController', function () {
                 assert.ok(imposter.toJSON.wasCalledWith({ replayable: false, removeProxies: false }), imposter.toJSON.message());
             });
         });
+
+        promiseIt('should delete requests recorded with the imposter', function () {
+            var response = FakeResponse.create(),
+                imposter = {
+                    toJSON: mock().returns('JSON'),
+                    deleteRequests: mock()
+                },
+                controller = Controller.create({ 1: imposter });
+
+            return controller.deleteRequests({ url: '/imposters/1/requests', params: { id: 1 } }, response).then(function () {
+                assert(imposter.deleteRequests.wasCalled());
+            });
+        });
+
     });
 });


### PR DESCRIPTION
Clears captured proxied requests leaving the imposter definition intact.
Useful in scenarios when server has captured 100's of requests and getting the captured request (using GET /imposter/xxx) takes lot of time. 
Does not have any impact on stubbed imposters.