### PR TITLE
exists predicate: handle integer and object values

### DIFF
--- a/src/models/predicates.js
+++ b/src/models/predicates.js
@@ -397,7 +397,7 @@ var predicates = {
     startsWith: create('startsWith', function (expected, actual) { return actual.indexOf(expected) === 0; }),
     endsWith: create('endsWith', function (expected, actual) { return actual.indexOf(expected, actual.length - expected.length) >= 0; }),
     matches: matches,
-    exists: create('exists', function (expected, actual) { return expected ? actual.length > 0 : actual.length === 0; }),
+    exists: create('exists', function (expected, actual) { return expected ? (actual !== undefined && actual !== '') : (actual === undefined || actual === ''); }),
     not: not,
     or: or,
     and: and,

--- a/test/models/predicates/existsTest.js
+++ b/test/models/predicates/existsTest.js
@@ -7,7 +7,7 @@ describe('predicates', function () {
     describe('#exists', function () {
         it('should return true for integer request field if exists is true', function () {
             var predicate = { exists: { field: true } },
-                request = { field: 10 };
+                request = { field: 0 };
             assert.ok(predicates.evaluate(predicate, request));
         });
 
@@ -37,7 +37,7 @@ describe('predicates', function () {
 
         it('should return false for integer request field if exists is false', function () {
             var predicate = { exists: { field: false } },
-                request = { field: 10 };
+                request = { field: 0 };
             assert.ok(!predicates.evaluate(predicate, request));
         });
 

--- a/test/models/predicates/existsTest.js
+++ b/test/models/predicates/existsTest.js
@@ -5,27 +5,63 @@ var assert = require('assert'),
 
 describe('predicates', function () {
     describe('#exists', function () {
-        it('should return true for non empty request field if exists is true', function () {
+        it('should return true for integer request field if exists is true', function () {
+            var predicate = { exists: { field: true } },
+                request = { field: 10 };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
+
+        it('should return true for object request field if exists is true', function () {
+            var predicate = { exists: { field: true } },
+                request = { field: {} };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
+
+        it('should return true for non empty string request field if exists is true', function () {
             var predicate = { exists: { field: true } },
                 request = { field: 'nonempty' };
             assert.ok(predicates.evaluate(predicate, request));
         });
-
-        it('should return false for empty request field if exists is true', function () {
+        
+        it('should return false for empty string request field if exists is true', function () {
             var predicate = { exists: { field: true } },
                 request = { field: '' };
             assert.ok(!predicates.evaluate(predicate, request));
         });
 
-        it('should return false for non empty request field if exists is false', function () {
+        it('should return false for undefined request field if exists is true', function () {
+            var predicate = { exists: { field: true } },
+                request = { field: undefined };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+
+        it('should return false for integer request field if exists is false', function () {
+            var predicate = { exists: { field: false } },
+                request = { field: 10 };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+
+        it('should return false for object request field if exists is false', function () {
+            var predicate = { exists: { field: false } },
+                request = { field: {} };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+        
+        it('should return false for non empty string request field if exists is false', function () {
             var predicate = { exists: { field: false } },
                 request = { field: 'nonempty' };
             assert.ok(!predicates.evaluate(predicate, request));
         });
 
-        it('should return true for empty request field if exists is false', function () {
+        it('should return true for empty string request field if exists is false', function () {
             var predicate = { exists: { field: false } },
                 request = { field: '' };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
+
+        it('should return true for undefined request field if exists is false', function () {
+            var predicate = { exists: { field: false } },
+                request = { field: undefined };
             assert.ok(predicates.evaluate(predicate, request));
         });
 


### PR DESCRIPTION
Addresses issue #299 

Before this change:

- `''` did not exist
- `undefined` did not exist
- `null` and `0` and `{}` _did not_ exist
- numbers _did not_ exist

After this change:
- `''` still doesn't exist
- `undefined` still doesn't exist
- `null` and `0` and `{}` _do_ exist
- numbers _do_ exist

In my opinion, `''` should exist since someone must've set that value at some point, but I understand that changing existing behaviour is tricky. I'd appreciate your thoughts.

Let me know if you have any questions.

This is my first code PR in the open source community. I was motivated to contribute as part of Hacktoberfest 2017: https://hacktoberfest.digitalocean.com/. Thanks for making this project so easy to set up locally with npm and grunt!!