### PR TITLE
Add support for per-imposter mock verification

### DIFF
--- a/src/models/abstractServer.js
+++ b/src/models/abstractServer.js
@@ -28,7 +28,7 @@ function implement (implementation, recordRequests, debug, baseLogger) {
      * @returns {Object} - The interface for all protocols
      */
     function create (options) {
-        options.recordRequests = recordRequests;
+        options.recordRequests = options.recordRequests || recordRequests;
         options.debug = debug;
 
         function scopeFor (port) {
@@ -88,7 +88,7 @@ function implement (implementation, recordRequests, debug, baseLogger) {
                 implementation.Request.createFrom(request).then(function (simpleRequest) {
                     logger.debug('%s => %s', clientName, JSON.stringify(server.formatRequest(simpleRequest)));
                     numRequests += 1;
-                    if (recordRequests) {
+                    if (options.recordRequests) {
                         var recordedRequest = helpers.clone(simpleRequest);
                         recordedRequest.timestamp = new Date().toJSON();
                         requests.push(recordedRequest);

--- a/src/views/docs/protocols/http.ejs
+++ b/src/views/docs/protocols/http.ejs
@@ -40,6 +40,15 @@ description = 'The HTTP protocol support by mountebank'
     <td>Included in the logs, useful when multiple imposters are set up.</td>
   </tr>
   <tr>
+    <td><code>recordRequests</code></td>
+    <td><code>true</code> or <code>false</code></td>
+    <td>No</td>
+    <td>false</td>
+    <td>Adds <a href='/docs/api/mocks'>mock verification</a> support by remembering the requests
+        made to this imposter.  Note that this represents a memory leak for any long running
+        <code>mb</code> process, as requests are never forgotten.</td>
+  </tr>
+  <tr>
     <td><code>stubs</code></td>
     <td>Valid stubs</td>
     <td>No</td>

--- a/src/views/docs/protocols/https.ejs
+++ b/src/views/docs/protocols/https.ejs
@@ -68,6 +68,15 @@ switch in <code>curl</code>).  Alternatively, you may pass in the key pair yours
     <td>Included in the logs, useful when multiple imposters are set up.</td>
   </tr>
   <tr>
+    <td><code>recordRequests</code></td>
+    <td><code>true</code> or <code>false</code></td>
+    <td>No</td>
+    <td>false</td>
+    <td>Adds <a href='/docs/api/mocks'>mock verification</a> support by remembering the requests
+        made to this imposter.  Note that this represents a memory leak for any long running
+        <code>mb</code> process, as requests are never forgotten.</td>
+  </tr>
+  <tr>
     <td><code>stubs</code></td>
     <td>Valid stubs</td>
     <td>No</td>

--- a/src/views/docs/protocols/smtp.ejs
+++ b/src/views/docs/protocols/smtp.ejs
@@ -43,6 +43,15 @@ mountebank expects stub responses will be acceptance or rejection of the message
     <td>empty string</td>
     <td>Included in the logs, useful when multiple imposters are set up.</td>
   </tr>
+  <tr>
+    <td><code>recordRequests</code></td>
+    <td><code>true</code> or <code>false</code></td>
+    <td>No</td>
+    <td>false</td>
+    <td>Adds <a href='/docs/api/mocks'>mock verification</a> support by remembering the requests
+        made to this imposter.  Note that this represents a memory leak for any long running
+        <code>mb</code> process, as requests are never forgotten.</td>
+  </tr>
 </table>
 
 <h2>SMTP Requests</h2>

--- a/src/views/docs/protocols/tcp.ejs
+++ b/src/views/docs/protocols/tcp.ejs
@@ -50,6 +50,15 @@ description = 'The TCP protocol support provided by mountebank, which allows cus
     <td>Included in the logs, useful when multiple imposters are set up.</td>
   </tr>
   <tr>
+    <td><code>recordRequests</code></td>
+    <td><code>true</code> or <code>false</code></td>
+    <td>No</td>
+    <td>false</td>
+    <td>Adds <a href='/docs/api/mocks'>mock verification</a> support by remembering the requests
+        made to this imposter.  Note that this represents a memory leak for any long running
+        <code>mb</code> process, as requests are never forgotten.</td>
+  </tr>
+  <tr>
     <td><code>stubs</code></td>
     <td>A stub request.</td>
     <td>No</td>


### PR DESCRIPTION
I have a long-running mb instance with multiple imposters and I only need one of them to record requests for mock verificatopm