### PR TITLE
Fix styling of GitHub's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ source developers, and they are legion.
 ## Roadmap and Support
 
 mountebank is used by a large number of companies and I think it's important to convey my best guess as to what
-the feature roadmap is. I've adopted github tools to manage the roadmap. Specifically, the
+the feature roadmap is. I've adopted GitHub tools to manage the roadmap. Specifically, the
 [Roadmap project](https://github.com/bbyars/mountebank/projects/9) page shows the features by release. I generally
 re-prioritize and update the ETAs each release. I'm in the middle of writing the mountebank book at the moment too,
 so please be patient.


### PR DESCRIPTION
GitHub is normally typed out as "GitHub" and not "github".

This is so incredibly minor and nit-picky, I wouldn't blame you if you ignored it. :)