### PR TITLE
adding proxyTransparent mode to issue requests without storing them in memory.

### DIFF
--- a/src/models/responseResolver.js
+++ b/src/models/responseResolver.js
@@ -188,6 +188,11 @@ function create (proxy, postProcess) {
     }
 
     function recordProxyResponse (responseConfig, request, response, stubs, logger) {
+        // proxyTransparent prevents the request from being recorded, and always transparently issues the request.
+        if ('proxyTransparent' == responseConfig.proxy.mode) {
+            return;
+        }
+
         if (['proxyOnce', 'proxyAlways'].indexOf(responseConfig.proxy.mode) < 0) {
             responseConfig.proxy.mode = 'proxyOnce';
         }

--- a/src/views/docs/api/proxies.ejs
+++ b/src/views/docs/api/proxies.ejs
@@ -39,13 +39,13 @@ in newly created <code>predicates</code>.</p>
   <tr>
     <td><code>mode</code></td>
     <td><code>proxyOnce</code></td>
-    <td>string, one of <code>proxyOnce</code> or <code>proxyAlways</code>.</td>
+    <td>string, one of <code>proxyOnce</code>, <code>proxyAlways</code> or <code>proxyTransparent</code>.</td>
     <td>Defines the replay behavior of the proxy. The default <code>proxyOnce</code> mode
         doesn't require you to explicitly do anything to replay the proxied responses. The
         <code>proxyAlways</code> mode requires you to run the
         <a href='/docs/commandLine'><code>mb replay</code></a> command (or equivalent) to
         switch from record mode to replay mode, but allows a richer set of data to be
-        recorded. See <a href='#proxy-modes'>below</a> for details.</td>
+        recorded. The <code>proxyTransparent</code> mode proxies the request but does not record any data. See <a href='#proxy-modes'>below</a> for details.</td>
   </tr>
   <tr>
     <td><code>addWaitBehavior</code></td>

--- a/src/views/docs/api/proxy/proxyModes.ejs
+++ b/src/views/docs/api/proxy/proxyModes.ejs
@@ -444,7 +444,7 @@ Host: localhost:<%= port %>
     </step>
 
     <p>Every time we send a request to <code>/test</code>, it will
-        be proxied to http://origin-server.com/test. There will be no stub created off the back of the request.
+        be proxied to http://origin-server.com/test. There will be no stub created off the back of the request.</p>
 
     <step type='http'>
         <code class='hidden'>GET /imposters/4000 HTTP/1.1
@@ -469,4 +469,3 @@ Host: localhost:<%= port %>
         </assertResponse>
     </step>
 </testScenario>
-

--- a/src/views/docs/api/proxy/proxyModes.ejs
+++ b/src/views/docs/api/proxy/proxyModes.ejs
@@ -6,8 +6,9 @@
       one response for each request, and automatically replays that response the next
       time the request predicates match.</li>
   <li><code>proxyAlways</code> - All calls will be proxied, allowing multiple responses
-      to be saved for the same logical request. You have to explicitly tell mountebank
-      to replay those responses.</li>
+        to be saved for the same logical request. You have to explicitly tell mountebank
+        to replay those responses.</li>
+  <li><code>proxyTransparent</code> - All calls will be proxied, but will not be recorded.</li>
 </ul>
 
 <h3>proxyOnce</h3>
@@ -410,3 +411,62 @@ Host: localhost:<%= port %>
 Accept: application/json</code>
     </step>
 </testScenario>
+
+
+
+
+<h3>proxyTransparent</h3>
+
+<p>The <code>proxyTransparent</code> mode does not save stubs <em>behind</em> the <code>proxy</code>
+    stub and simply proxies the requests transparently.</p>
+
+<p>Let's say you had the following <code>stubs</code> array:</p>
+
+<testScenario name='proxyTransparent'>
+
+    <step type='http'>
+<pre><code><span class='hidden'>POST /imposters HTTP/1.1
+Host: localhost:<%= port %>
+            Content-Type: application/json
+
+{
+  "port": 4000,
+  "protocol": "http",
+</span>"stubs": [{
+  "responses": [{
+    "proxy": {
+      "to": "<change to='http://localhost:4001'>http://origin-server.com</change>",
+      <strong class='highlight1'>"mode": "proxyTransparent"</strong>,
+      "predicateGenerators": [{ "matches": { "path": true } }]
+    }
+  }]
+}]<span class='hidden'>}</span></code></pre>
+    </step>
+
+    <p>Every time we send a request to <code>/test</code>, it will
+        be proxied to http://origin-server.com/test. There will be no stub created off the back of the request.
+
+    <step type='http'>
+        <code class='hidden'>GET /imposters/4000 HTTP/1.1
+            Host: localhost:<%= port %>
+            Accept: application/json</code>
+
+        <assertResponse partial='true'>
+<pre><code><span class='hidden'>{
+</span>"stubs": [
+  {
+    "responses": [
+      {
+        "proxy": {
+          "to": "<change to='http://localhost:4001'>http://origin-server.com</change>",
+          "mode": "proxyTransparent",
+          "predicateGenerators": [{ "matches": { "path": true } }]
+        }
+      }
+    ]
+  }
+]<span class='hidden'>}</span></code></pre>
+        </assertResponse>
+    </step>
+</testScenario>
+

--- a/src/views/docs/api/proxy/proxyModes.ejs
+++ b/src/views/docs/api/proxy/proxyModes.ejs
@@ -427,10 +427,10 @@ Accept: application/json</code>
     <step type='http'>
 <pre><code><span class='hidden'>POST /imposters HTTP/1.1
 Host: localhost:<%= port %>
-            Content-Type: application/json
+Content-Type: application/json
 
 {
-  "port": 4000,
+  "port": 5001,
   "protocol": "http",
 </span>"stubs": [{
   "responses": [{
@@ -447,7 +447,7 @@ Host: localhost:<%= port %>
         be proxied to http://origin-server.com/test. There will be no stub created off the back of the request.</p>
 
     <step type='http'>
-        <code class='hidden'>GET /imposters/4000 HTTP/1.1
+        <code class='hidden'>GET /imposters/5001 HTTP/1.1
             Host: localhost:<%= port %>
             Accept: application/json</code>
 

--- a/src/views/faqs.ejs
+++ b/src/views/faqs.ejs
@@ -59,7 +59,7 @@ description = 'Frequently asked questions about using mountebank'
         to make all <code>Connection</code> headers as <code>Keep-Alive</code>. As long as you set up each <code>mb</code>
         instance with the same configuration, you can run multiple instances behind a load balancer. Given a
         reasonable hardware setup, organizations have reported managing 200-250 TPS per instance. A common
-        strategy is to set up a <a href='/docs/api/proxies'>proxy</a> in <code>proxyAlways</code> mode
+        strategy is to set up a <a href='/docs/api/proxies'>proxy</a> in <code>proxyAlways</code> or <code>proxyTransparent</code> mode
         and to capture the downstream latency by using the <code>addWaitBehavior</code> field to the proxy.
         When you replay the saved responses, they will add the perform with roughly the same latency the
         downstream services had.</dd>


### PR DESCRIPTION
We are currently using an in-house proxy testing solution similar to mountebank and are looking to replace it with mountebank.

However one of the features we need is to be able to add a proxyTransparent(or whatever name we agree) mode that allows us to transparently issue requests where no other predicate matches without recording the response. 