### PR TITLE
Fix daemon configuration docs link

### DIFF
--- a/src/views/docs/install.ejs
+++ b/src/views/docs/install.ejs
@@ -69,7 +69,7 @@ var versionPath = encodeURIComponent(version);
 
 <h2 id='system-daemon'>Running as a system daemon</h2>
 You can also configure mountebank to run as a unix system daemon. A sample ansible playbook and systemd configuration file is
-available [here](https://github.com/bbyars/mountebank/tree/master/scripts/install) (Tested on RHEL7 and Centos7).
+available <a href="https://github.com/bbyars/mountebank/tree/master/scripts/install">here</a> (Tested on RHEL7 and Centos7).
 
 <h2 id='windows-path-limitations'>Windows path limitations</h2>
 


### PR DESCRIPTION
The installation docs page was using markdown syntax for the link. Updated to be an anchor tag.