### PR TITLE
Upgrade https-proxy-agent due to security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mountebank",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5320,9 +5320,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
         "agent-base": "4.2.0",
         "debug": "3.1.0"
@@ -5331,7 +5331,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "errorhandler": "^1.0.0",
     "express": "~4.16.2",
     "http-proxy-agent": "^2.0.0",
-    "https-proxy-agent": "2.1.1",
+    "https-proxy-agent": "^2.2.1",
     "json-stable-stringify": "~1.0.0",
     "jsonpath-plus": "^0.16.0",
     "mailparser": "~0.6.1",


### PR DESCRIPTION
Upgrading [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) to latest version to fix this issue: https://github.com/bbyars/mountebank/issues/346