### PR TITLE
Fixing some typos ("the" word repeated in the documentation)

### DIFF
--- a/src/views/docs/api/contracts/imposter-description.ejs
+++ b/src/views/docs/api/contracts/imposter-description.ejs
@@ -344,7 +344,7 @@
 <div id='imposter-stubs-predicates-equals-jsonpath-description'>
     <p>It is common to want to use predicates on JSON response bodies, but annoying to treat the JSON as
         simple text with many of the predicates.  mountebank uses the <code>json</code> predicate parameter
-        to narrow the scope of the predicate value to a value matched by the the json selector.</p>
+        to narrow the scope of the predicate value to a value matched by the json selector.</p>
 
     <p class='info-icon'>More information: <a href='/docs/api/jsonpath'>jsonpath</a></p>
 </div>
@@ -352,7 +352,7 @@
 <div id='imposter-stubs-predicates-equals-xpath-description'>
   <p>It is common to want to use predicates on XML response bodies, but annoying to treat the XML as
     simple text with many of the predicates.  mountebank uses the <code>xpath</code> predicate parameter
-    to narrow the scope of the predicate value to a value matched by the the xpath selector.</p>
+    to narrow the scope of the predicate value to a value matched by the xpath selector.</p>
 
   <p class='info-icon'>More information: <a href='/docs/api/xpath'>xpath</a></p>
 </div>

--- a/src/views/docs/api/injection.ejs
+++ b/src/views/docs/api/injection.ejs
@@ -152,7 +152,7 @@ and response to the <code>state</code> variable, and only proxies if certain req
 parameters have not already been sent.</p>
 
 <p>The example below will use two imposters, an origin server and a server that proxies
-to the the origin server.  It would be better implemented using
+to the origin server.  It would be better implemented using
 <a href='/docs/api/proxies'>a proxy response type</a>, but has sufficient complexity to
 demonstrate many nuances of injection.</p>
 

--- a/src/views/docs/api/jsonpath.ejs
+++ b/src/views/docs/api/jsonpath.ejs
@@ -10,7 +10,7 @@ description = 'Using JsonPath in mountebank predicates'
 <p>It is common for mountebank to see JSON documents in his line of business, and he suspects
     the same may be true for you.  With the goal of making JSON easier to work with, mountebank
     accepts a <code>jsonpath</code> predicate parameter.  This parameter narrows the scope of the predicate
-    value to a value matched by the the jsonpath selector, much like the <a href='/docs/api/predicates'>
+    value to a value matched by the jsonpath selector, much like the <a href='/docs/api/predicates'>
         <code>except</code> parameter</a>.  mountebank suggests avoiding using this parameter on fields
     that are not JSON documents.  He also counsels avoiding the temptation to use it with binary protocols.</p>
 

--- a/src/views/docs/api/proxies.ejs
+++ b/src/views/docs/api/proxies.ejs
@@ -10,7 +10,7 @@ description = 'Using mountebank to record and playback through proxying to a rea
 <p>Proxies are one of the most powerful features of mountebank, rivaled only by the
 mighty <a href='/docs/api/injection'>injection.</a>  Proxies support record/replay
 behavior to easily capture a rich set of test data for your test scenarios.
-Each proxy definition allows you to define the the fields which should be included
+Each proxy definition allows you to define the fields which should be included
 in newly created <code>predicates</code>.</p>
 
 <p><code>proxy</code> response types take the following parameters:</p>

--- a/src/views/docs/api/xpath.ejs
+++ b/src/views/docs/api/xpath.ejs
@@ -10,7 +10,7 @@ description = 'Using XPath in mountebank predicates'
 <p>It is common for mountebank to see XML documents in his line of business, and he suspects
 the same may be true for you.  With the goal of making making XML easier to work with, mountebank
 accepts an <code>xpath</code> predicate parameter.  This parameter narrows the scope of the predicate
-value to a value matched by the the xpath selector, much like the <a href='/docs/api/predicates'>
+value to a value matched by the xpath selector, much like the <a href='/docs/api/predicates'>
 <code>except</code> parameter</a>.  mountebank suggests avoiding using this parameter on fields
 that are not XML documents.  He also counsels avoiding the temptation to use it with binary protocols.</p>
 


### PR DESCRIPTION
Little PR to remove the duplication of the "the" word in the documentation.