### PR TITLE
Removing more repeated words

### DIFF
--- a/src/views/docs/api/behaviors/lookup.ejs
+++ b/src/views/docs/api/behaviors/lookup.ejs
@@ -183,7 +183,7 @@ Content-Type: application/json
 }</code></pre>
     </step>
 
-<p>As with the <code>copy</code> behavior, we we can plug tokens into any of the response fields
+<p>As with the <code>copy</code> behavior, we can plug tokens into any of the response fields
 (including the <code>statusCode</code>). Let's see what happens when we craft a request to match
 all of those selectors:</p>
 

--- a/src/views/docs/api/xpath.ejs
+++ b/src/views/docs/api/xpath.ejs
@@ -8,7 +8,7 @@ description = 'Using XPath in mountebank predicates'
 <h1>Using XPath</h1>
 
 <p>It is common for mountebank to see XML documents in his line of business, and he suspects
-the same may be true for you.  With the goal of making making XML easier to work with, mountebank
+the same may be true for you.  With the goal of making XML easier to work with, mountebank
 accepts an <code>xpath</code> predicate parameter.  This parameter narrows the scope of the predicate
 value to a value matched by the xpath selector, much like the <a href='/docs/api/predicates'>
 <code>except</code> parameter</a>.  mountebank suggests avoiding using this parameter on fields


### PR DESCRIPTION
Just found out more repeated words while checking the doc ... this time I wanted to check all the source files so I wrote this small go program to check line by line the doc files:

```
package main

import (
	"bufio"
	"fmt"
	"log"
	"os"
	"strings"
)

func main() {
	args := os.Args
	if len(args) == 0 {
		fmt.Errorf("Wrong arguments ... ")
	}

	file, err := os.Open(args[1])
	if err != nil {
		log.Fatalln(err)
	}
	defer file.Close()

	scanner := bufio.NewScanner(file)
	line := 0
	for scanner.Scan() {
		line++
		text := scanner.Text()
		words := strings.Fields(text)
		for i := 0; i < len(words)-1; i++ {
			if words[i] == words[i+1] {
				fmt.Printf("repeated words in: %d line, words '%s' and '%s' ~~> '%s'\n", line, words[i], words[i+1], file.Name())
			}
		}

	}

}

```

Usage: 
`find . -type f -name '*.ejs' -exec ~/code/golang_code/countwords/countwords {} \;`