### PR TITLE
Parse form when content type is x-www-form-urlencoded;charset=UTF-8

### DIFF
--- a/src/models/http/httpRequest.js
+++ b/src/models/http/httpRequest.js
@@ -40,11 +40,16 @@ function transform (request) {
         body: request.body
     };
 
-    if (request.body && headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+    if (request.body && isForm(headers['Content-Type'])) {
         transformed.form = queryString.parse(request.body);
     }
 
     return transformed;
+}
+
+function isForm (contentType) {
+    return contentType === 'application/x-www-form-urlencoded' ||
+        contentType === 'application/x-www-form-urlencoded;charset=UTF-8';
 }
 
 /**

--- a/test/models/http/httpRequestTest.js
+++ b/test/models/http/httpRequestTest.js
@@ -89,6 +89,29 @@ describe('HttpRequest', function () {
             return promise;
         });
 
+        promiseIt('should transform form for application/x-www-form-urlencoded;charset=UTF-8', function () {
+            request.rawHeaders = [
+                'Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8',
+                'Host', '127.0.0.1:8000'
+            ];
+
+            var promise = httpRequest.createFrom(container).then(function (mbRequest) {
+                assert.deepEqual(mbRequest.headers, {
+                    'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                    Host: '127.0.0.1:8000'
+                });
+                assert.deepEqual(mbRequest.form, {
+                    firstname: 'ruud',
+                    lastname: 'mountebank'
+                });
+            });
+
+            request.emit('data', 'firstname=ruud&lastname=mountebank');
+            request.emit('end');
+
+            return promise;
+        });
+
         promiseIt('should set path and query from request url', function () {
             request.url = 'http://localhost/path?key=value';
 


### PR DESCRIPTION
Currently it only parses form when the content type is "application/x-www-form-urlencoded". "application/x-www-form-urlencoded;charset=UTF-8" should be supported as well