### PR TITLE
Respects `host` header set via injectHeaders

### DIFF
--- a/functionalTest/api/http/httpProxyStubTest.js
+++ b/functionalTest/api/http/httpProxyStubTest.js
@@ -504,7 +504,7 @@ describe('http proxy stubs', () => {
             const mirrorPort = port + 2;
 
             const proxyStub = { responses: [{ proxy: { to: `http://localhost:${mirrorPort}`,
-                    injectHeaders: { 'X-Forwarded-Host': 'http://www.google.com', 'Host': 'colbert' } } }] },
+                    injectHeaders: { 'X-Forwarded-Host': 'http://www.google.com', Host: 'colbert' } } }] },
                 proxyStubRequest = { protocol: 'http', port: proxyPort, stubs: [proxyStub], name: 'proxy stub' },
                 mirrorStub = { responses: [{ is: { body: '' }, _behaviors: {
                     decorate: ((request, response) => { response.headers = request.headers; }).toString() } }] },
@@ -518,7 +518,7 @@ describe('http proxy stubs', () => {
                 return client.get('/', proxyPort);
             }).then(response => {
                 assert.equal(response.headers['x-forwarded-host'], 'http://www.google.com');
-                assert.equal(response.headers['host'], 'colbert');
+                assert.equal(response.headers.host, 'colbert');
             }).finally(() => api.del('/imposters'));
         });
     }

--- a/functionalTest/api/http/httpProxyStubTest.js
+++ b/functionalTest/api/http/httpProxyStubTest.js
@@ -504,7 +504,7 @@ describe('http proxy stubs', () => {
             const mirrorPort = port + 2;
 
             const proxyStub = { responses: [{ proxy: { to: `http://localhost:${mirrorPort}`,
-                    injectHeaders: { 'X-Forwarded-Host': 'http://www.google.com' } } }] },
+                    injectHeaders: { 'X-Forwarded-Host': 'http://www.google.com', 'Host': 'colbert' } } }] },
                 proxyStubRequest = { protocol: 'http', port: proxyPort, stubs: [proxyStub], name: 'proxy stub' },
                 mirrorStub = { responses: [{ is: { body: '' }, _behaviors: {
                     decorate: ((request, response) => { response.headers = request.headers; }).toString() } }] },
@@ -518,6 +518,7 @@ describe('http proxy stubs', () => {
                 return client.get('/', proxyPort);
             }).then(response => {
                 assert.equal(response.headers['x-forwarded-host'], 'http://www.google.com');
+                assert.equal(response.headers['host'], 'colbert');
             }).finally(() => api.del('/imposters'));
         });
     }

--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -63,7 +63,10 @@ const create = logger => {
                 ciphers: proxyOptions.ciphers || 'ALL',
                 rejectUnauthorized: false
             };
-        options.headers.host = hostnameFor(parts.protocol, parts.hostname, options.port);
+        // Only set host header if not overridden via injectHeaders (issue #388)
+        if (!proxyOptions.injectHeaders || !headersHelper.hasHeader('host', proxyOptions.injectHeaders)) {
+            options.headers.host = hostnameFor(parts.protocol, parts.hostname, options.port);
+        }
         setProxyAgent(parts, options);
 
         // Avoid implicit chunked encoding (issue #132)


### PR DESCRIPTION
Ensures that a `host` header, set via the `injectHeaders` proxy
option, is properly set in the proxied requests.

Adds relevant test coverage.

CC: @jnb

Fixes #388 