### PR TITLE
added guard against empty text

### DIFF
--- a/src/models/smtp/smtpRequest.js
+++ b/src/models/smtp/smtpRequest.js
@@ -31,7 +31,7 @@ function transform (session, email) {
         priority: email.priority || 'normal',
         references: email.references || [],
         inReplyTo: email.inReplyTo || [],
-        text: email.text.trim(),
+        text: (email.text || '').trim(),
         html: (email.html || '').trim(),
         attachments: email.attachments || []
     };


### PR DESCRIPTION
while using mountebank with a smtp imposter discovered that emails with html body only (i.e. not plain text) generated the following error:

```
info: [smtp:50318 smtp-imposter-CWNY01DEV016] ::1:51640 => Envelope from: undefined to: undefined                                  
error: [smtp:50318 smtp-imposter-CWNY01DEV016] ::1:51640 X=> {"domain":{"domain":null,"_events":{},"_eventsCount":1,"members":[]},"
domainThrown":true,"message":"Cannot read property 'trim' of undefined","name":"TypeError","stack":"TypeError: Cannot read property
 'trim' of undefined\n    at transform (C:\\Users\\Santiago.Vasquez\\AppData\\Roaming\\npm\\node_modules\\mountebank\\src\\models\\
smtp\\smtpRequest.js:32:22)\n    at simpleParser (C:\\Users\\Santiago.Vasquez\\AppData\\Roaming\\npm\\node_modules\\mountebank\\src
\\models\\smtp\\smtpRequest.js:52:30)\n    at parser.updateImageLinks (C:\\Users\\Santiago.Vasquez\\AppData\\Roaming\\npm\\node_mod
ules\\mountebank\\node_modules\\mailparser2\\lib\\simple-parser.js:78:17)\n    at Immediate.processNext [as _onImmediate] (C:\\User
s\\Santiago.Vasquez\\AppData\\Roaming\\npm\\node_modules\\mountebank\\node_modules\\mailparser2\\lib\\mail-parser.js:785:24)\n    a
t runCallback (timers.js:810:20)\n    at tryOnImmediate (timers.js:768:5)\n    at processImmediate [as _immediateCallback] (timers.
js:745:5)"}                                                                                                                        
```