### PR TITLE
Fix HTTP binary option not liking newlines in base64

### DIFF
--- a/functionalTest/api/http/httpStubTest.js
+++ b/functionalTest/api/http/httpStubTest.js
@@ -335,6 +335,26 @@ const assert = require('assert'),
                 }).finally(() => api.del('/imposters'));
             });
 
+            promiseIt('should correctly set content-length for binary data when using multiline base64', function () {
+                const stub = {
+                        responses: [{
+                            is: {
+                                headers: { 'Content-Length': 274 },
+                                body: 'iVBORw0KGgoAAAANSUhEUgAAAGQAAAAyBAMAAABYG2ONAAAAFVBMVEUAAAD///9/f39fX1+fn58f\nHx8/Pz8rYiDqAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAo0lEQVRIie2Qyw7CIBBFb2DwO5q+1o0L\n1w0NrrHRPQnV//8EAUl0ga1ujIs5CZAz4YYZAIZhmN/QQOkjzq3LLuv6xUrQHmTJGphcEGE9rUQ3\nY4bqqrDjAlgQoJK9Z8YBmFy8Gp8DeSeTfRSBCf2I6/JN5ORiRfrNiIfqh9S9SVPL27A1C0G4EX2e\nJR7J1iI7rbG0Vf4x0UwPW0Uh3i0bwzD/yR11mBj1DIKiVwAAAABJRU5ErkJggg==\n',
+                                _mode: 'binary'
+                            }
+                        }]
+                    },
+                    request = { protocol, port, stubs: [stub] };
+
+                return api.post('/imposters', request).then(response => {
+                    assert.strictEqual(response.statusCode, 201, response.body);
+                    return client.get('/', port);
+                }).then(response => {
+                    assert.deepEqual(response.headers['content-length'], 274);
+                }).finally(() => api.del('/imposters'));
+            });
+
             promiseIt('should handle JSON null values', function () {
                 // https://github.com/bbyars/mountebank/issues/209
                 const stub = { responses: [{ is: { body: { name: 'test', type: null } } }] },

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -46,6 +46,12 @@ module.exports = function (createBaseServer) {
                 }
             }
 
+            if (encoding === 'base64') {
+                // ensure the base64 has no newlines or other non
+                // base64 chars that will cause the body to be garbled.
+                response.body = response.body.replace(/[^A-Za-z0-9=+/]+/g, '');
+            }
+
             if (!headersHelper.hasHeader('Connection', response.headers)) {
                 // Default to close connections, because a test case
                 // may shutdown the stub, which prevents new connections for

--- a/src/views/docs/protocols/http.ejs
+++ b/src/views/docs/protocols/http.ejs
@@ -173,9 +173,6 @@ to <code>binary</code> and base64 encode the <code>body</code>.  mountebank will
 to preserve binary responses in proxies by looking at the <code>Content-Encoding</code> and
 <code>Content-Type</code> headers.</p>
 
-<p>Note that the base64 must be on a single line with no newlines anywhere, otherwise the
-binary response will be garbled.</p>
-
 <h2 id='inline-json-response-bodies'>Inline JSON For Response Bodies</h2>
 
 <p>The example below shows passing an inline JSON object as the response body.</p>


### PR DESCRIPTION
While trying to set an http mock to return a binary response I found that mountebank doesn't like the base65 to be on anything other than a single line.  I had expected to be able to take the output of `base64 file.png` and simply pass that to mountebank.  Using `base64 -w0 file.png` will generate the correct output.

I'm not sure if this is actually a problem with mountebank as it's possibly more something with the underlying nodejs it's calling.

I've created a test that demonstrates the issue in case you want to fix it.  I guess the simplest thing would be to fudge it to remove all the newlines.