### PR TITLE
Add note about base64

### DIFF
--- a/src/views/docs/protocols/http.ejs
+++ b/src/views/docs/protocols/http.ejs
@@ -173,6 +173,9 @@ to <code>binary</code> and base64 encode the <code>body</code>.  mountebank will
 to preserve binary responses in proxies by looking at the <code>Content-Encoding</code> and
 <code>Content-Type</code> headers.</p>
 
+<p>Note that the base64 must be on a single line with no newlines anywhere, otherwise the
+binary response will be garbled.</p>
+
 <h2 id='inline-json-response-bodies'>Inline JSON For Response Bodies</h2>
 
 <p>The example below shows passing an inline JSON object as the response body.</p>


### PR DESCRIPTION
While trying to set an http mock to return a binary response I found that mountebank doesn't like the base65 to be on anything other than a single line.  I had expected to be able to take the output of `base64 file.png` and simply pass that to mountebank.  Using `base64 -w0 file.png` will generate the correct output.

This is a minor note in the documentation that documents that behaviour for now.