### PR TITLE
fix issue https://github.com/bbyars/mountebank/issues/404

### DIFF
--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -69,6 +69,10 @@ function create (logger) {
                 ciphers: proxyOptions.ciphers || 'ALL',
                 rejectUnauthorized: false
             };
+        //For allow overide  "secureProtocol"
+        if (proxyOptions.secureProtocol) {
+            options['secureProtocol'] = proxyOptions.secureProtocol
+        }
         // Only set host header if not overridden via injectHeaders (issue #388)
         if (!proxyOptions.injectHeaders || !headersHelper.hasHeader('host', proxyOptions.injectHeaders)) {
             options.headers.host = hostnameFor(parts.protocol, parts.hostname, options.port);


### PR DESCRIPTION
How to override secure Protocol (TLSv1_method,TLSv2_method,TLSv3_method,etc..)
```
{
"responses": [
     {
         "proxy": {
         "to": "https://myserver.test.com",
         "mode": "proxyAlways",
         "secureProtocol": "TLSv1_method",  //SSLv2_method, SSLv3_method
         "cert": "-----BEGIN CERTIFICATE-----",
         "ciphers": "RC4-MD5"
      }
    }
]
}
```