### PR TITLE
Predicate generator injection

### DIFF
--- a/src/models/responseResolver.js
+++ b/src/models/responseResolver.js
@@ -108,15 +108,15 @@ function create (stubs, proxy, callbackURL) {
         matchers.forEach(matcher => {
             if (matcher.inject) {
                 const injected = `(${matcher.inject})(request);`,
-                      errors = require('../util/errors');
+                    errors = require('../util/errors');
                 try {
-                    predicates.push(...injected);
+                    predicates.push(...eval(injected));
                 }
                 catch (error) {
                     logger.error(`injection X=> ${error}`);
                     logger.error(`    source: ${JSON.stringify(injected)}`);
                     logger.error(`    request: ${JSON.stringify(request)}`);
-                    throw errors.InjectionError('invalid predicate generator injection', { source: injected, data: error.message });
+                    throw errors.InjectionError('invalid predicateGenerator injection', { source: injected, data: error.message });
                 }
                 return;
             }

--- a/src/models/responseResolver.js
+++ b/src/models/responseResolver.js
@@ -106,6 +106,21 @@ function create (stubs, proxy, callbackURL) {
         const predicates = [];
 
         matchers.forEach(matcher => {
+            if (matcher.inject) {
+                const injected = `(${matcher.inject})(request);`,
+                      errors = require('../util/errors');
+                try {
+                    predicates.push(...injected);
+                }
+                catch (error) {
+                    logger.error(`injection X=> ${error}`);
+                    logger.error(`    source: ${JSON.stringify(injected)}`);
+                    logger.error(`    request: ${JSON.stringify(request)}`);
+                    throw errors.InjectionError('invalid predicate generator injection', { source: injected, data: error.message });
+                }
+                return;
+            }
+
             const basePredicate = {};
             let valueOf = field => field;
 

--- a/src/views/docs/api/proxy/predicateGenerators.ejs
+++ b/src/views/docs/api/proxy/predicateGenerators.ejs
@@ -51,6 +51,13 @@ array takes the following fields:</p>
     <td>Defines an object containing a <code>selector</code> string. The predicate's
     scope is limited to the selected value in the request field.</td>
   </tr>
+  <tr>
+    <td><code>inject</code></td>
+    <td><code>null</code></td>
+    <td>string</td>
+    <td>Defines a JavaScript function that accepts a <code>request</code> parameter
+    and returns a list of predicates to add to the stub.</td>
+  </tr>
 </table>
 
 <p>With the exception of <code>matches</code>, the fields correspond to the standard

--- a/test/models/responseResolverTest.js
+++ b/test/models/responseResolverTest.js
@@ -7,7 +7,8 @@ const assert = require('assert'),
     promiseIt = require('../testHelpers').promiseIt,
     mock = require('../mock').mock,
     Q = require('q'),
-    Logger = require('../fakes/fakeLogger');
+    Logger = require('../fakes/fakeLogger'),
+    util = require('util');
 
 describe('responseResolver', function () {
 
@@ -368,6 +369,78 @@ describe('responseResolver', function () {
                         responses: [response]
                     }
                 ]);
+            });
+        });
+
+        promiseIt('should support "inject" predicateGenerators', function () {
+            const proxy = { to: mock().returns(Q({ key: 'value' })) },
+                stubs = StubRepository.create('utf8'),
+                resolver = ResponseResolver.create(stubs, proxy),
+                logger = Logger.create(),
+                response = {
+                    proxy: {
+                        to: 'where',
+                        mode: 'proxyOnce',
+                        predicateGenerators: [{
+                            inject: 'function(request) { return [{ deepEquals: request, caseSensitive: true }, { not: { equals: { foo: "bar" }}}]; }'
+                        }]
+                    }
+                },
+                request = { key: 'Test' };
+
+            stubs.addStub({ responses: [response] });
+            const responseConfig = stubs.getResponseFor({}, logger, {});
+
+            return resolver.resolve(responseConfig, request, logger, {}).then(() => {
+                assert.deepEqual(stubList(stubs), [
+                    {
+                        predicates: [{
+                            deepEquals: { key: 'Test' },
+                            caseSensitive: true
+                        }, {
+                            not: {
+                                equals: { foo: 'bar' }
+                            }
+                        }],
+                        responses: [{ is: { key: 'value' } }]
+                    },
+                    {
+                        responses: [response]
+                    }
+                ]);
+            });
+        });
+
+        promiseIt('should log "inject" predicateGenerator exceptions', function () {
+            const errorsLogged = [],
+                proxy = { to: mock().returns(Q({ key: 'value' })) },
+                stubs = StubRepository.create('utf8'),
+                resolver = ResponseResolver.create(stubs, proxy),
+                logger = Logger.create(),
+                response = {
+                    proxy: {
+                        to: 'where',
+                        mode: 'proxyOnce',
+                        predicateGenerators: [{
+                            inject: 'function(request) { throw Error("BOOM!!!"); }'
+                        }]
+                    }
+                },
+                request = { key: 'Test' };
+
+            logger.error = function () {
+                const message = util.format.apply(this, Array.prototype.slice.call(arguments));
+                errorsLogged.push(message);
+            };
+
+            stubs.addStub({ responses: [response] });
+            const responseConfig = stubs.getResponseFor({}, logger, {});
+
+            return resolver.resolve(responseConfig, request, logger, {}).then(() => {
+                assert.fail('should have thrown exception');
+            }).catch(error => {
+                assert.strictEqual(error.message, 'invalid predicateGenerator injection');
+                assert.ok(errorsLogged.indexOf('injection X=> Error: BOOM!!!') >= 0);
             });
         });
 


### PR DESCRIPTION
Adds an `inject` predicateGenerator that specifies a JS function that takes a `request` parameter and returns a list of predicates. Example usage:
```js
...
"predicateGenerators": [{
    "inject": "function(request) { return [{'caseSensitive': true, 'deepEquals': {'body': request.headers['Content-Type'] === 'application/json' ? JSON.parse(request.body) : request.body}}]; }"
}],
...
```