### PR TITLE
Proxy HTTP requests using 'binary' encoding

### DIFF
--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -81,12 +81,12 @@ function create (logger) {
         if (originalRequest.body &&
             !headersHelper.hasHeader('Transfer-Encoding', originalRequest.headers) &&
             !headersHelper.hasHeader('Content-Length', originalRequest.headers)) {
-            options.headers['Content-Length'] = Buffer.byteLength(originalRequest.body);
+            options.headers['Content-Length'] = Buffer.byteLength(originalRequest.body, 'binary');
         }
 
         const proxiedRequest = protocol.request(options);
         if (originalRequest.body) {
-            proxiedRequest.write(originalRequest.body);
+            proxiedRequest.write(originalRequest.body, 'binary');
         }
         return proxiedRequest;
     }

--- a/src/models/http/httpRequest.js
+++ b/src/models/http/httpRequest.js
@@ -54,7 +54,7 @@ function createFrom (request) {
     const Q = require('q'),
         deferred = Q.defer();
     request.body = '';
-    request.setEncoding('utf8');
+    request.setEncoding('binary');
     request.on('data', chunk => { request.body += chunk; });
     request.on('end', () => { deferred.resolve(transform(request)); });
     return deferred.promise;


### PR DESCRIPTION
This seems to pass tests and meet my use case ¯\\\_(ツ)\_/¯