### PR TITLE
Preventing "except" parameter from modifying "matches" predicate pattern

### DIFF
--- a/src/models/predicates.js
+++ b/src/models/predicates.js
@@ -342,7 +342,8 @@ function matches (predicate, request, encoding) {
     const caseSensitive = predicate.caseSensitive ? true : false, // convert to boolean even if undefined
         helpers = require('../util/helpers'),
         clone = helpers.merge(predicate, { caseSensitive: true, keyCaseSensitive: caseSensitive }),
-        expected = normalize(predicate.matches, clone, { encoding: encoding }),
+        noexcept = helpers.merge(clone, { except: '' }),
+        expected = normalize(predicate.matches, noexcept, { encoding: encoding }),
         actual = normalize(request, clone, { encoding: encoding, withSelectors: true }),
         options = caseSensitive ? '' : 'i',
         errors = require('../util/errors');

--- a/test/models/predicates/matchesTest.js
+++ b/test/models/predicates/matchesTest.js
@@ -125,5 +125,15 @@ describe('predicates', function () {
                 request = { headers: { field: 'begin middle end' } };
             assert.ok(predicates.evaluate(predicate, request));
         });
+        it('should correctly strip "except" predicate from request field and return false', function () {
+            const predicate = { matches: { field: 'ab' }, except: 'ab' },
+                request = { field: 'abcde' };
+            assert.ok(!predicates.evaluate(predicate, request));
+        });
+        it('should correctly strip "except" predicate from request field and return true', function () {
+            const predicate = { matches: { field: '^\\d{1,10}$' }, except: '\\D' },
+                request = { field: '1+2' };
+            assert.ok(predicates.evaluate(predicate, request));
+        });
     });
 });


### PR DESCRIPTION
[The documentation](http://www.mbtest.org/docs/api/predicates) states that "except" parameter: "Defines a regular expression that is stripped out of the request field before matching." But in case of "matches" predicate it also strips out the regular expression from the predicate's pattern.

Current master branch behaviour makes the first test from this PR to test `'cde'` against `//` regex instead of `/ab/`, and the second - to test `'12'` against `/110/` instead of `/^\d{1,10}$/`.