### PR TITLE
Fix parsing application/x-www-form-urlencoded request body when its conent-type header name is in lowercase

### DIFF
--- a/src/models/http/headersHelper.js
+++ b/src/models/http/headersHelper.js
@@ -22,6 +22,14 @@ function hasHeader (headerName, headers) {
     return Object.keys(headers).some(header => header.toLowerCase() === headerName.toLowerCase());
 }
 
+function getHeader (headerName, headers) {
+    return headers[headerNameFor(headerName, headers)];
+}
+
+function setHeader (headerName, value, headers) {
+    headers[headerNameFor(headerName, headers)] = value;
+}
+
 function headerNameFor (headerName, headers) {
     const helpers = require('../../util/helpers'),
         result = Object.keys(headers).find(header => header.toLowerCase() === headerName.toLowerCase());
@@ -36,11 +44,9 @@ function headerNameFor (headerName, headers) {
 
 function getJar (headers) {
     return {
-        get: header => headers[headerNameFor(header, headers)],
-        set: (header, value) => {
-            headers[headerNameFor(header, headers)] = value;
-        }
+        get: header => getHeader(header, headers),
+        set: (header, value) => setHeader(header, value, headers)
     };
 }
 
-module.exports = { headersFor, hasHeader, headerNameFor, getJar };
+module.exports = { headersFor, hasHeader, headerNameFor, getJar, getHeader, setHeader };

--- a/src/models/http/httpRequest.js
+++ b/src/models/http/httpRequest.js
@@ -25,7 +25,8 @@ function transform (request) {
         ip: request.socket.remoteAddress
     };
 
-    if (request.body && isUrlEncodedForm(headers['Content-Type'])) {
+    const contentType = headersHelper.getHeader('Content-Type', headers);
+    if (request.body && isUrlEncodedForm(contentType)) {
         transformed.form = queryString.parse(request.body);
     }
 

--- a/test/models/http/headersHelperTest.js
+++ b/test/models/http/headersHelperTest.js
@@ -4,6 +4,66 @@ const assert = require('assert'),
     headersHelper = require('../../../src/models/http/headersHelper');
 
 describe('headersHelper', function () {
+    describe('#getHeader', function () {
+        const request = {
+                headers: {
+                    'My-First-header': 'first-value',
+                    'my-Second-Header': 'second-value'
+                }
+            },
+            getHeader = headersHelper.getHeader;
+
+        it('should search for the header with case-insensity', function () {
+            assert.equal(getHeader('my-first-headEr', request.headers), 'first-value');
+            assert.equal(getHeader('my-SECOND-header', request.headers), 'second-value');
+        });
+
+        it('should return undefined if the header is not present', function () {
+            assert.equal(getHeader('Missing-Header', request.headers), undefined);
+        });
+    });
+
+    describe('#setHeader', function () {
+        const setHeader = headersHelper.setHeader;
+
+        it('should not change the casing if the header exists', function () {
+            const request = {
+                headers: {
+                    'My-First-header': 'first-value',
+                    'my-Second-Header': 'second-value'
+                }
+            };
+
+            setHeader('my-first-headEr', 'new-value', request.headers);
+            assert.deepEqual(
+                request.headers,
+                {
+                    'My-First-header': 'new-value',
+                    'my-Second-Header': 'second-value'
+                }
+            );
+        });
+
+        it('should keep the casing intact for new headers', function () {
+            const request = {
+                headers: {
+                    'My-First-header': 'first-value',
+                    'my-Second-Header': 'second-value'
+                }
+            };
+
+            setHeader('My-Third-Header', 'third-value', request.headers);
+            assert.deepEqual(
+                request.headers,
+                {
+                    'My-First-header': 'first-value',
+                    'my-Second-Header': 'second-value',
+                    'My-Third-Header': 'third-value'
+                }
+            );
+        });
+    });
+
     describe('#getJar', function () {
         describe('#get', function () {
             it('should search for the header with case-insensity', function () {

--- a/test/models/http/httpRequestTest.js
+++ b/test/models/http/httpRequestTest.js
@@ -71,16 +71,20 @@ describe('HttpRequest', function () {
             return shouldTransformForm('application/x-www-form-urlencoded; charset=UTF-8');
         });
 
-        function shouldTransformForm (contentType) {
+        promiseIt('should transform form with lowercased content-type header name', function () {
+            return shouldTransformForm('application/x-www-form-urlencoded', 'content-type');
+        });
+
+        function shouldTransformForm (contentType, contentTypeHeader = 'Content-Type') {
             request.rawHeaders = [
-                'Content-Type', contentType,
+                contentTypeHeader, contentType,
                 'Host', '127.0.0.1:8000'
             ];
 
             const promise = httpRequest.createFrom(request).then(mbRequest => {
                 assert.deepEqual(mbRequest.headers, {
-                    'Content-Type': contentType,
-                    Host: '127.0.0.1:8000'
+                    Host: '127.0.0.1:8000',
+                    [contentTypeHeader]: contentType
                 });
                 assert.deepEqual(mbRequest.form, {
                     firstname: 'ruud',


### PR DESCRIPTION
In some cases request comes with lowercase content type header name: `content-type: application/x-www-form-urlencoded`. 
It happens, say, when the request comes from some node.js proxy that passes `request.headers` directly into upstream request headers (as `h2o2` hapi plugin does) causing all of them become lowercased.
When it happens, mb does not parse application/x-www-form-urlencoded request body and all the `form` field predicates fail.