### PR TITLE
Avoid error with too many unauthed SMTP commands

### DIFF
--- a/src/models/smtp/smtpServer.js
+++ b/src/models/smtp/smtpServer.js
@@ -11,6 +11,7 @@ function create (options, logger, responseFn) {
         connections = {},
         SMTPServer = require('smtp-server').SMTPServer,
         server = new SMTPServer({
+            maxAllowedUnauthenticatedCommands: 1000,
             disableReverseLookup: true,
             authOptional: true,
             onConnect (socket, callback) {


### PR DESCRIPTION
At $work we use mountebank to test our perl application (mb is great btw). Since upgrading to the newer version with the new SMTP server, tests started to fail with:

`Error: too many unauthenticated commands`

This is a small Perl program to reproduce the issue, I wasn't quite sure how to turn it into a JavaScript test, sorry:

```perl
use strict;
use warnings;

use Email::Sender::Transport::SMTP::Persistent;
use Email::Stuffer;
use HTTP::Tiny;
use Net::SMTP;

my $pid = fork // die or exec qw/mb start/;

sleep 1;

HTTP::Tiny->new->post(
    'http://localhost:2525/imposters',
    { content => '{"port":1025,"protocol":"smtp"}' },
);

my $tran = Email::Sender::Transport::SMTP::Persistent->new( port => 1025 );

for ( 1 .. 3 ) {
    Email::Stuffer->from('from@foo.com')->to('to@bar.com')->text_body('baz')
        ->transport($tran)->send_or_die;

    sleep 1;
}

END { kill 'KILL', $pid }
```
```
info: [mb:2525] mountebank v2.1.0 now taking orders - point your browser to http://localhost:2525/ for help
info: [mb:2525] POST /imposters
info: [smtp:1025] Open for business...
info: [smtp:1025] ::1:37518 => Envelope from: {"address":"from@foo.com","name":""} to: [{"address":"to@bar.com","name":""}]
info: [smtp:1025] ::1:37518 => Envelope from: {"address":"from@foo.com","name":""} to: [{"address":"to@bar.com","name":""}]
from@foo.com failed after MAIL FROM: Error: too many unauthenticated commands
```

Setting the `maxAllowedUnauthenticatedCommands` option to the `SMTPServer` constructor alleviates this but I wasn't sure what value to set it to so I just copied https://github.com/ReachFive/fake-smtp-server/pull/10/files