### PR TITLE
Add support for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:12
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+EXPOSE 2525
+CMD ["mb"]


### PR DESCRIPTION
Adding support for building in Docker so that Mountebank can be easily built by anyone.
Also, as a future action, it would be useful to automatically build new images on new tags and push them to Dockerhub.

cc @bbyars 