### PR TITLE
Implement endpoint for clearing saved imposter requests

### DIFF
--- a/functionalTest/api/http/httpImposterTest.js
+++ b/functionalTest/api/http/httpImposterTest.js
@@ -242,5 +242,25 @@ const assert = require('assert'),
                 });
             });
         });
+
+        describe('DELETE /imposters/:id/savedRequests', function () {
+            promiseIt('shold return the imposter post requests-deletion', function () {
+                const imposterRequest = { protocol, port, recordRequests: true };
+
+                return api.post('/imposters', imposterRequest)
+                    .then(() => client.get('/first', port))
+                    .then(() => api.get(`/imposters/${port}`))
+                    .then(response => {
+                        const requests = response.body.requests.map(request => request.path);
+                        assert.deepEqual(requests, ['/first']);
+                    })
+                    .then(() => api.del(`/imposters/${port}/savedRequests`))
+                    .then(() => api.get(`/imposters/${port}`))
+                    .then(response => {
+                        assert.deepEqual(response.body.requests, []);
+                    })
+                    .finally(() => api.del('/imposters'));
+            });
+        });
     });
 });

--- a/src/controllers/imposterController.js
+++ b/src/controllers/imposterController.js
@@ -86,6 +86,33 @@ function create (protocols, imposters, logger, allowInjection) {
     }
 
     /**
+     * Corresponds to DELETE /imposters/:id/savedRequests
+     * Removes all saved requests
+     * @memberOf module:controllers/imposterController#
+     * @param {Object} request - the HTTP request
+     * @param {Object} response - the HTTP response
+     * @returns {Object} A promise for testing
+     */
+    function resetRequests (request, response) {
+        return imposters.get(request.params.id).then(imposter => {
+            return imposters.stubsFor(request.params.id).deleteSavedRequests()
+                .then(() => imposter.toJSON());
+        }).then(json => {
+            response.format({
+                json: () => { response.send(json); },
+                html: () => {
+                    if (request.headers['x-requested-with']) {
+                        response.render('_imposter', { imposter: json });
+                    }
+                    else {
+                        response.render('imposter', { imposter: json });
+                    }
+                }
+            });
+        });
+    }
+
+    /**
      * The function responding to DELETE /imposters/:id
      * @memberOf module:controllers/imposterController#
      * @param {Object} request - the HTTP request
@@ -326,6 +353,7 @@ function create (protocols, imposters, logger, allowInjection) {
         get,
         del,
         resetProxies,
+        resetRequests,
         postRequest,
         postProxyResponse,
         putStubs,

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -659,6 +659,16 @@ function create (config, logger) {
             return loadAllInDir(`${baseDir}/requests`);
         }
 
+        /**
+         * Deletes the requests directory for an mposter
+         * @returns {Object} - Promise
+         */
+        function deleteSavedRequests () {
+            return readAndWriteHeader('deleteSavedRequests', header => {
+                return remove(`${baseDir}/requests`).then(() => header);
+            });
+        }
+
         return {
             count,
             first,
@@ -670,7 +680,8 @@ function create (config, logger) {
             toJSON,
             deleteSavedProxyResponses,
             addRequest,
-            loadRequests
+            loadRequests,
+            deleteSavedRequests
         };
     }
 

--- a/src/models/inMemoryImpostersRepository.js
+++ b/src/models/inMemoryImpostersRepository.js
@@ -101,8 +101,8 @@ function wrap (stub = {}) {
  */
 function createStubsRepository () {
     const stubs = [],
-        requests = [],
         Q = require('q');
+    let requests = [];
 
     function reindex () {
         // stubIndex() is used to find the right spot to insert recorded
@@ -256,6 +256,16 @@ function createStubsRepository () {
         return Q(requests);
     }
 
+    /**
+     * Clears the saved requests list
+     * @param {Object} request - the request
+     * @returns {Object} - Promise
+     */
+    function deleteSavedRequests () {
+        requests = [];
+        return Q();
+    }
+
     return {
         count: () => stubs.length,
         first,
@@ -267,7 +277,8 @@ function createStubsRepository () {
         toJSON,
         deleteSavedProxyResponses,
         addRequest,
-        loadRequests
+        loadRequests,
+        deleteSavedRequests
     };
 }
 

--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -230,6 +230,7 @@ function create (options) {
     app.get('/imposters/:id', validateImposterExists, imposterController.get);
     app.delete('/imposters/:id', imposterController.del);
     app.delete('/imposters/:id/savedProxyResponses', validateImposterExists, imposterController.resetProxies);
+    app.delete('/imposters/:id/savedRequests', validateImposterExists, imposterController.resetRequests);
 
     // deprecated but saved for backwards compatibility
     app.delete('/imposters/:id/requests', validateImposterExists, imposterController.resetProxies);

--- a/src/views/docs/api/mocks.ejs
+++ b/src/views/docs/api/mocks.ejs
@@ -20,7 +20,8 @@ verification. Mocking requires mountebank to remember information about each req
 For long-running instances of mountebank, it is recommended that you run <code>mb</code> with the
 <code>--datadir</code> command line option so that all requests are persisted to disk. Otherwise,
 mountebank will save them to memory, which will create a significant performance constraint
-when there are a large number of requests saved.</p>
+when there are a large number of requests saved. You can also manually clear an imposter's saved 
+requests - see the <a href='/docs/api/overview'>overview page</a> for details.</p>
 
 <h2>Example</h2>
 

--- a/src/views/docs/api/overview.ejs
+++ b/src/views/docs/api/overview.ejs
@@ -70,6 +70,11 @@ will happily assist you.</p>
     <td></td>
   </tr>
   <tr>
+    <td><a href='#delete-requests'>Delete saved requests from an imposter</a></td>
+    <td></td>
+    <td><a href='/docs/api/contracts?type=imposter'>imposter</a></td>
+  </tr>
+  <tr>
     <td><a href='#put-imposters'>Overwrite all imposters with a new set of imposters</a></td>
     <td><a href='/docs/api/contracts?type=imposters'>imposters</a></td>
     <td><a href='/docs/api/contracts?type=imposters'>imposters</a></td>
@@ -590,6 +595,15 @@ available. However, if you need to clear them but keep the stubs intact, you can
 
 <p class='info-icon'>Note that you can prevent the proxy from saving responses by setting the <code>mode</code>
 to <a href='/docs/api/proxies#proxy-modes'><code>proxyTransparent</code></a>.</p>
+
+<h3 id='delete-requests'>Delete saved requests from an imposter</h3>
+
+<pre><code>DELETE /imposters/:port/savedRequests</code></pre>
+
+<p><b>Response contract</b>: <a href='/docs/api/contracts?type=imposter'>imposter</a></p>
+
+<p>Clear an imposter's recorded requests (used for <a href='/docs/api/mocks'>mock verification</a>) while leaving the rest of the imposter intact. 
+On a successful request, mountebank will return the updated imposter resource.</p>
 
 <h3 id='put-imposters'>Overwrite all imposters with a new set of imposters</h3>
 

--- a/test/models/filesystemBackedImpostersRepositoryTest.js
+++ b/test/models/filesystemBackedImpostersRepositoryTest.js
@@ -632,5 +632,28 @@ describe('filesystemBackedImpostersRepository', function () {
                 });
             });
         });
+
+        describe('#deleteSavedRequests', function () {
+            promiseIt('should delete the imposter\'s requests/ directory', function () {
+                const stubs = repo.stubsFor(3000),
+                    imposter = { port: 3000, protocol: 'test', stubs: [] };
+
+                return repo.add(imposterize(imposter))
+                    .then(() => stubs.addRequest({ field: 'value' })
+                        .then(() => {
+                            const requestFiles = fs.readdirSync('.mbtest/3000/requests');
+                            assert(requestFiles.length, 1);
+                        })
+                        .then(() => stubs.loadRequests())
+                        .then(requests => {
+                            assert.deepEqual(requests, [{ field: 'value', timestamp: requests[0].timestamp }]);
+                        })
+                        .then(() => stubs.deleteSavedRequests())
+                        .then(() => {
+                            const imposterDir = fs.readdirSync('.mbtest/3000');
+                            assert(imposterDir.includes('requests') === false);
+                        }));
+            });
+        });
     });
 });

--- a/test/models/impostersRepositoryContractTest.js
+++ b/test/models/impostersRepositoryContractTest.js
@@ -644,6 +644,24 @@ types.forEach(function (type) {
                 });
             });
 
+            describe('#deleteSavedRequests', function () {
+                promiseIt('should clear the requests list', function () {
+                    const imposter = { port: 1 };
+
+                    return repo.add(imposterize(imposter))
+                        .then(() => repo.stubsFor(1).addRequest({ field: 'value' }))
+                        .then(() => repo.stubsFor(1).loadRequests())
+                        .then(requests => {
+                            assert.deepEqual(requests, [{ field: 'value', timestamp: requests[0].timestamp }]);
+                        })
+                        .then(() => repo.stubsFor(1).deleteSavedRequests())
+                        .then(() => repo.stubsFor(1).loadRequests())
+                        .then(requests => {
+                            assert.deepEqual(requests, []);
+                        });
+                });
+            });
+
             describe('#loadRequests', function () {
                 promiseIt('should return requests in order without losing any', function () {
                     // Simulate enough rapid load to add two with the same millisecond timestamp


### PR DESCRIPTION
Implement the endpoint `DELETE /imposters/:id/savedRequests`, which clears the saved requests for an imposter while leaving the rest of it untouched. In-memory repository works by just resetting `requests = []`, while the file system repository removes the `requests/` dir for an imposter. PR includes unit and functional tests, docs, and linting.

Example usage:
```bash
# mb must be up
$ curl -X POST -H 'Content-Type: application/json' http://localhost:2525/imposters --data '{"port":3000, "protocol":"http", "recordRequests": true}'
$ curl http://localhost:3000
$ curl http://localhost:2525/imposters/3000 # "requests" res contains previous req
$ curl -X DELETE http://localhost:2525/imposters/3000/savedRequests # "requests" res is cleared
```

Misc:
- There is some inconsistency around how "delete/clear/reset" terms are already being used - I tried to model my nomenclature after code relevant to `/imposters/:port/savedProxyResponses` per each file, but happy to change that as requested.
- Grunt airplane passes all tests except for five, all related to `--host` binding. I'm assuming it's something about my local environment and not related to the code changes.

![mb_grunt_test_failures](https://user-images.githubusercontent.com/8431044/75924157-7146d800-5e34-11ea-9a3b-b2fefb3f81e4.png)
