### PR TITLE
Add docker production image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:12
+
+ENV MOUNTEBANK_VERSION=2.2.0
+RUN npm install -g mountebank@${MOUNTEBANK_VERSION} --production
+
+RUN mkdir /imposters
+COPY ./imposters /imposters
+VOLUME /imposters
+
+WORKDIR /imposters
+
+EXPOSE 2525
+
+ENTRYPOINT ["mb"]
+CMD ["start", "--configfile", "imposters.ejs"]
+

--- a/docker/imposters/imposters.ejs
+++ b/docker/imposters/imposters.ejs
@@ -1,0 +1,30 @@
+{
+  "imposters": [
+    {
+      "port": 8080,
+      "protocol": "http",
+      "stubs": [
+        {
+          "predicates": [
+            {
+              "deepEquals": {
+                "method": "GET"
+              }
+            }
+          ],
+          "responses": [
+            {
+              "is": {
+                "statusCode": 200,
+                "body": {
+                  "status": "Imposter Running!"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
#### :tophat: What? Why?

Hi mountebank community, I think we should have a production docker image, I needed it on the past so should be great if you accept my PR.

I'm also trying to add this to the official supported docker images:

- docker-library/official-images#7740
- docker-library/docs#1693

#### ❓ What it does?
This docker image get the latest version from `npm` in production, after that create a volume with a imposter example. In this way we can have an out-of-the-box demo. 

```console
docker run --rm -p 8080:8080 mountebank:latest
```

Every one who wants to use this image, just need to rewrite the volume `/imposters` with the custom imposters.

```console
docker run --rm -v /path/to/imposters:/imposters -p 8080:8080 mountebank:latest
```

It use the `ENTRYPOINT` to make it easier to run, you can rewrite the command if you need to.

```console
docker run --rm  -v /path/to/imposters:/imposters \
                    -p 8080:8080 \
                    mountebank:latest \
                    start --configfile myimposters.ejs 
```

Or even with a docker-compose file:

```yaml
version: '3'
services:
  mountebank:
    image: mountebank:2.2.0
    ports:
      - "2525:2525"
      - "8080:8080"
    volumes:
      - /path/to/imposters:/imposters
    command: start --configfile /imposters/custom-imposters.ejs --allowInjection
```