### PR TITLE
Add Action to publish docker image on Github registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,28 @@
+---
+name: Docker
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      IMAGE: docker.pkg.github.com/bbyars/mountebank/mountebank
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Login docker registry
+      run: |
+        docker login docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+    - name: Build docker image
+      run: |
+        docker build -f docker/Dockerfile ./docker \
+        --build-arg version=${GITHUB_REF:11} \
+        -t $IMAGE:${GITHUB_REF:11} -t $IMAGE:latest
+    - name: Publish docker image
+      run: |
+        docker push $IMAGE:${GITHUB_REF:11}
+        docker push $IMAGE:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12
 
-ENV MOUNTEBANK_VERSION=2.2.0
-RUN npm install -g mountebank@${MOUNTEBANK_VERSION} --production
+ARG version=2.2.0
+RUN npm install -g mountebank@${version} --production
 
 RUN mkdir /imposters
 COPY ./imposters /imposters


### PR DESCRIPTION
Hello, with this now we can publish the docker image on the Github registry the example below:

To being able to publish a new image you need to make a new release tag on Github. Also is expected that the tag has this format `vX.X.X` and the npm package should exist already. We can also add the npm publish to the same Github action, but that is more complex.

## 🗒️Tasks
- We can also publish to the docker hub registry but we need the secret
- We can publish the npm package also with the secrets

![image](https://user-images.githubusercontent.com/1911813/79287468-82e6bb00-7e89-11ea-97ec-5b71bec766cb.png)


