### PR TITLE
Update --protofile option to use absolute/relative paths

### DIFF
--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -103,7 +103,7 @@ function loadCustomProtocols (protofile, logger) {
 
     const fs = require('fs'),
         path = require('path'),
-        filename = path.join(process.cwd(), protofile);
+        filename = path.resolve(path.relative(process.cwd(), protofile));
 
     if (fs.existsSync(filename)) {
         try {


### PR DESCRIPTION
Hello, I found when debugging the --protofile option the value was only working with a relative path. This change is to find the relative path to the `process.cwd()` and then resolve the absolute path (so it still works with the require).

Also, I did read your guidelines but didn't see any existing tests for mountebank.js (and didn't add any). I tested this manually on linux with with node v14 to check it worked with absolute/relative paths.