### PR TITLE
Fixing performance test issues (MacOS Catalina/Node 12)

### DIFF
--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -80,8 +80,6 @@
  * @module
  */
 
-
-
 /**
  * Creates the repository
  * @param {Object} config - The database configuration


### PR DESCRIPTION
Changes:

1. Deferred around the lock operation
2. Increased the number of acquisition retries to 15 -- will still see an intermittent failure at 10 :/
3. Added an fs.stat call around the rename. The rename will fail intermittently with certain AV or backup software because the write doesn't show on the IMMEDIATELY file system after the write callback is completed.