### PR TITLE
Decrease docker image size by removing npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-alpine
 
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --production && npm cache clean -f
 COPY . .
 
 EXPOSE 2525


### PR DESCRIPTION
Deletes npm cache after npm install --production
Apparently decreases image size by a few MB. #580 

![mountebank_docker_npm_cache_clean](https://user-images.githubusercontent.com/40319304/101028634-d2a3ff00-359e-11eb-84c3-ac79a6d83a36.PNG)
