### PR TITLE
Leverage docker build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:14-alpine
 
 WORKDIR /app
+COPY package*.json ./
+RUN npm install --production && npm cache clean -f
 COPY bin/ bin/
 COPY src/ src/
-COPY package*.json releases.json LICENSE README.md ./
-RUN npm install --production && npm cache clean -f
+COPY releases.json LICENSE README.md ./
 
 EXPOSE 2525
 ENTRYPOINT ["node", "bin/mb"]


### PR DESCRIPTION
This will leverage docker build cache as suggested in [Best practices for writing Dockerfiles.](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy)
 
Files: package.json and package.lock.json are not changing as often as files in /src or /bin. 
Before every change in files in  /src or /bin invalidates docker build cache for layer with npm install.
After it works like that (simple change in .src):

```
 => CACHED [2/7] WORKDIR /app                                              0.0s
 => CACHED [3/7] COPY package*.json ./                                     0.0s
 => CACHED [4/7] RUN npm install --production && npm cache clean -f        0.0s
 => CACHED [5/7] COPY bin/ bin/                                            0.0s
 => [6/7] COPY src/ src/
```
