### PR TITLE
Set maxShellCommandLength to 2048 in all environments

### DIFF
--- a/src/models/behaviors.js
+++ b/src/models/behaviors.js
@@ -156,8 +156,7 @@ function execShell (command, request, response, logger) {
     const exec = require('child_process').exec,
         env = require('../util/helpers').clone(process.env),
         maxBuffer = require('buffer').constants.MAX_STRING_LENGTH,
-        isWindows = require('os').platform().indexOf('win') === 0,
-        maxShellCommandLength = isWindows ? 2048 : 100000;
+        maxShellCommandLength = 2048;
 
     logger.debug(`Shelling out to ${command}`);
 


### PR DESCRIPTION
Following on from [this discussion](https://groups.google.com/g/mountebank-discuss/c/31gddJEteR8/m/USFgH0vxBAAJ?pli=1) in the support group, this PR changes the `maxShellCommandLength` to 2048 for all environments. Preventing issues in linux containers (as well as windows) when executing shell commands for requests with large payloads.