### PR TITLE
feat: support proxy connect method

### DIFF
--- a/mbTest/api/http/httpProxyStubTest.js
+++ b/mbTest/api/http/httpProxyStubTest.js
@@ -4,10 +4,12 @@ const assert = require('assert'),
     fs = require('fs-extra'),
     api = require('../../api').create(),
     client = require('../../baseHttpClient').create('http'),
+    clientSecure = require('../../baseHttpClient').create('https'),
     port = api.port + 1,
     isWindows = require('os').platform().indexOf('win') === 0,
     timeout = isWindows ? 10000 : parseInt(process.env.MB_SLOW_TEST_TIMEOUT || 2000),
-    airplaneMode = process.env.MB_AIRPLANE_MODE === 'true';
+    airplaneMode = process.env.MB_AIRPLANE_MODE === 'true',
+    { HttpsProxyAgent } = require('hpagent');
 
 function isInProcessImposter (protocol) {
     if (fs.existsSync('protocols.json')) {
@@ -88,6 +90,36 @@ describe('http proxy stubs', function () {
 
         assert.strictEqual(response.statusCode, 400);
         assert.strictEqual(response.body, 'ERROR');
+    });
+
+    // https://github.com/bbyars/mountebank/issues/600
+    it('should handle the connect method', async function () {
+        const proxy = {
+            protocol: 'https',
+            port: port,
+            stubs: [
+                { responses: [{ proxy: { to: 'https://api.github.com:443' } }] }
+            ]
+        };
+        await api.createImposter(proxy);
+
+        const response = await clientSecure.responseFor({
+            host: 'api.github.com',
+            path: '/repos/bbyars/mountebank/contents/README.md',
+            port: 443,
+            agent: new HttpsProxyAgent({
+                keepAlive: true,
+                proxy: `https://localhost:${proxy.port}`
+            }),
+            headers: {
+                'User-Agent': 'Mountebank Proxy Test <http://mbtest.org>'
+            }
+        });
+
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.body.name, 'README.md');
+        assert.strictEqual(response.body.path, 'README.md');
+        assert.strictEqual(response.body.type, 'file');
     });
 
     it('should update the host header to the origin server', async function () {

--- a/mbTest/baseHttpClient.js
+++ b/mbTest/baseHttpClient.js
@@ -3,8 +3,7 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 function create (protocol) {
-    const driver = require(protocol),
-        agent = new driver.Agent({ keepAlive: true });
+    const driver = require(protocol);
 
     function optionsFor (spec) {
         if (!spec.hostname) {
@@ -23,6 +22,10 @@ function create (protocol) {
     async function responseFor (spec) {
         const options = optionsFor(spec);
 
+        if (!spec.agent && !spec.createConnection) {
+            options.agent = new driver.Agent({ keepAlive: true });
+        }
+
         if (!options.port) {
             throw Error('silly rabbit, you forgot to pass the port again');
         }
@@ -30,8 +33,6 @@ function create (protocol) {
         if (spec.body && !options.headers['Content-Type']) {
             options.headers['Content-Type'] = 'application/json';
         }
-
-        options.agent = agent;
 
         return new Promise((resolve, reject) => {
             const request = driver.request(options, response => {

--- a/mbTest/package-lock.json
+++ b/mbTest/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "fs-extra": "9.0.1",
+                "hpagent": "0.1.1",
                 "jsdom": "16.4.0",
                 "mocha": "8.2.1",
                 "mocha-multi-reporters": "1.5.1",
@@ -1217,6 +1218,11 @@
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+        },
+        "node_modules/hpagent": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+            "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ=="
         },
         "node_modules/html-encoding-sniffer": {
             "version": "2.0.1",
@@ -4186,6 +4192,11 @@
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+        },
+        "hpagent": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+            "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ=="
         },
         "html-encoding-sniffer": {
             "version": "2.0.1",

--- a/mbTest/package.json
+++ b/mbTest/package.json
@@ -23,6 +23,7 @@
     },
     "dependencies": {
         "fs-extra": "9.0.1",
+        "hpagent": "0.1.1",
         "jsdom": "16.4.0",
         "mocha": "8.2.1",
         "mocha-multi-reporters": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "devDependencies": {
         "coveralls": "^3.1.0",
-        "eslint": "^7.21.0",
+        "eslint": "7.21.0",
         "eslint-plugin-mocha": "8.0.0",
         "eslint-plugin-node": "11.1.0",
         "firebase-tools": "9.1.0",
@@ -11197,6 +11197,7 @@
       "resolved": "https://registry.npmjs.org/re2/-/re2-1.15.9.tgz",
       "integrity": "sha512-AXWEhpMTBdC+3oqbjdU07dk0pBCvxh5vbOMLERL6Y8FYBSGn4vXlLe8cYszn64Yy7H8keVMrgPzoSvOd4mePpg==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "install-artifact-from-github": "^1.2.0",

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -74,16 +74,12 @@ module.exports = function (createBaseServer) {
             // may we prefer this method instead?
             const proxyServer = net.createConnection({ host, port }, () => {
                 client.on('error', err => {
-                    // 'ECONNRESET' appears to be a no-op?
-                    if (err.code !== 'ECONNRESET') {
-                        logger.error('CLIENT TO PROXY ERROR: %o', err);
-                    }
+                    logger.warn('CLIENT TO PROXY ERROR: [%s] %s', err.code, err.message);
+                    logger.debug('%s', err.stack);
                 });
                 proxyServer.on('error', err => {
-                    // 'EPIPE' appears to be a no-op?
-                    if (err.code !== 'EPIPE') {
-                        logger.error('SERVER PROXY ERROR: %o', err);
-                    }
+                    logger.warn('SERVER PROXY ERROR: [%s] %s', err.code, err.message);
+                    logger.debug('%s', err.stack);
                 });
 
                 logger.info('PROXY TO SERVER SET UP TO %s ON %s', host, port);

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -74,10 +74,9 @@ module.exports = function (createBaseServer) {
             // may we prefer this method instead?
             const proxyServer = net.createConnection({ host, port }, () => {
                 client.on('error', err => {
-                    // 'ECONNRESET' IS no-op?
+                    // 'ECONNRESET' appears to be a no-op?
                     if (err.code !== 'ECONNRESET') {
-                        console.log('CLIENT TO PROXY ERROR');
-                        console.log(err);
+                        logger.error('CLIENT TO PROXY ERROR: %o', err);
                     }
                 });
 

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -79,6 +79,12 @@ module.exports = function (createBaseServer) {
                         logger.error('CLIENT TO PROXY ERROR: %o', err);
                     }
                 });
+                proxyServer.on('error', err => {
+                    // 'EPIPE' appears to be a no-op?
+                    if (err.code !== 'EPIPE') {
+                        logger.error('SERVER PROXY ERROR: %o', err);
+                    }
+                });
 
                 logger.info('PROXY TO SERVER SET UP TO %s ON %s', host, port);
                 client.write('HTTP/1.1 200 Connection established\r\n\r\n');


### PR DESCRIPTION
This fixes #600.

We had some trouble implementing this functionality in the tests, and even had trouble finding any node library that handled this out of the box. Eventually, we hit on the right combination of things and reverse-engineered it. This PR does still include a new dependency, `hpagent`, which provides the custom agent that handles the extra handshake requirements on the client request side. I don't know that it is worth the effort to try to peel that out as well.

Happy to hear your thoughts @bbyars!
