### PR TITLE
#608 added support for  as content-encoding, and identify it as bin

### DIFF
--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -125,7 +125,7 @@ function create (logger) {
         const contentEncoding = headers['content-encoding'] || '',
             contentType = headers['content-type'] || '';
 
-        if (BINARY_CONTENT_ENCODINGS.some( binEncoding => contentEncoding.indexOf(binEncoding) > 0))
+        if (BINARY_CONTENT_ENCODINGS.some( binEncoding => contentEncoding.indexOf(binEncoding) >= 0))
         {
             return true;
         }

--- a/src/models/http/httpProxy.js
+++ b/src/models/http/httpProxy.js
@@ -13,6 +13,9 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
  * @returns {Object}
  */
 function create (logger) {
+    const BINARY_CONTENT_ENCODINGS = [
+        "gzip", "br", "compress", "deflate"
+    ];
     const BINARY_MIME_TYPES = [
         'audio/',
         'application/epub+zip',
@@ -122,7 +125,8 @@ function create (logger) {
         const contentEncoding = headers['content-encoding'] || '',
             contentType = headers['content-type'] || '';
 
-        if (contentEncoding.indexOf('gzip') >= 0) {
+        if (BINARY_CONTENT_ENCODINGS.some( binEncoding => contentEncoding.indexOf(binEncoding) > 0))
+        {
             return true;
         }
 

--- a/src/models/http/httpRequest.js
+++ b/src/models/http/httpRequest.js
@@ -62,6 +62,12 @@ function createFrom (request) {
                 }
                 catch (error) { /* do nothing */ }
             }
+            else if (contentEncoding === 'br') {
+                try {
+                    request.body = zlib.brotliDecompressSync(buffer).toString();
+                }
+                catch (error) { /* do nothing */ }
+            }
             else {
                 request.body = buffer.toString();
             }


### PR DESCRIPTION
Hi Bbyars,

I have been fiddling with mountebank for the last few weeks, I am setting this up for my mocked automation tests. However, I had some issue when setting up a proxy to an api that that returned content as `br` compression. More details are explains in my issue #608 

This is my attempt to fix the issue.

After the code change, the content is properly recogized as binary and getting decompress properly.