### PR TITLE
Return endOfRequestResolver if defined

### DIFF
--- a/mbTest/api/tcp/tcpImposterTest.js
+++ b/mbTest/api/tcp/tcpImposterTest.js
@@ -80,5 +80,20 @@ describe('tcp imposter', function () {
                 }
             });
         });
+
+        it('should return the provided end of request resolver', async function() {
+            const basicResolver = config => { return config.request.Length >= 100; },
+                request = {
+                    protocol: 'tcp',
+                    port,
+                    endOfRequestResolver: { inject: basicResolver.toString() }
+                };
+
+            await api.createImposter(request);
+            const response = await api.get(`/imposters/${port}`),
+                imposter = response.body;
+
+            assert.strictEqual(imposter.endOfRequestResolver.inject, basicResolver.toString());
+        })
     });
 });

--- a/mbTest/api/tcp/tcpImposterTest.js
+++ b/mbTest/api/tcp/tcpImposterTest.js
@@ -81,7 +81,7 @@ describe('tcp imposter', function () {
             });
         });
 
-        it('should return the provided end of request resolver', async function() {
+        it('should return the provided end of request resolver', async function () {
             const basicResolver = config => { return config.request.Length >= 100; },
                 request = {
                     protocol: 'tcp',
@@ -94,6 +94,6 @@ describe('tcp imposter', function () {
                 imposter = response.body;
 
             assert.strictEqual(imposter.endOfRequestResolver.inject, basicResolver.toString());
-        })
+        });
     });
 });

--- a/src/models/imposterPrinter.js
+++ b/src/models/imposterPrinter.js
@@ -25,6 +25,9 @@ function create (header, server, loadRequests) {
                 result[key] = server.metadata[key];
             });
         }
+        if (header.endOfRequestResolver) {
+            result.endOfRequestResolver = header.endOfRequestResolver;
+        }
 
         return result;
     }


### PR DESCRIPTION
Similarly to #645, this adds the `endOfRequestResolver` value to the `imposter` contract.

The docs call out that `endOfRequestResolver` is specifically for TCP imposters, but I didn't see anything that was obviously a specialized printer for TCP imposters, so I just added it to `imposterPrinter.js`. If there's a more appropriate place for it, feel free to move it there.