### PR TITLE
Fix predicate structure in imposter contract docs

### DIFF
--- a/src/views/docs/api/contracts/imposter-description.ejs
+++ b/src/views/docs/api/contracts/imposter-description.ejs
@@ -340,27 +340,27 @@
   <p class='info-icon'>More information: <a href='/docs/api/predicates'>predicates</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-equals-description'>
+<div id='imposter-stubs-predicates-0-equals-description'>
   <p>A type of predicate that requires the given request fields to equal the predicate value.
     By default, mountebank uses a case-insensitive equality.</p>
 
   <p class='info-icon'>More information: <a href='/docs/api/predicates'>predicates</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-equals-caseSensitive-description'>
+<div id='imposter-stubs-predicates-0-caseSensitive-description'>
   <p>If true, mountebank will require the request field to satisfy the predicate value in
     a case sensitive comparison.</p>
 
   <p class='info-icon'>More information: <a href='/docs/api/predicates'>predicates</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-equals-except-description'>
+<div id='imposter-stubs-predicates-0-except-description'>
   <p>Defines a regular expression that is stripped out of the request field before matching.</p>
 
   <p class='info-icon'>More information: <a href='/docs/api/predicates'>predicates</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-equals-jsonpath-description'>
+<div id='imposter-stubs-predicates-0-jsonpath-description'>
     <p>It is common to want to use predicates on JSON response bodies, but annoying to treat the JSON as
         simple text with many of the predicates.  mountebank uses the <code>json</code> predicate parameter
         to narrow the scope of the predicate value to a value matched by the json selector.</p>
@@ -368,7 +368,7 @@
     <p class='info-icon'>More information: <a href='/docs/api/jsonpath'>jsonpath</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-equals-xpath-description'>
+<div id='imposter-stubs-predicates-0-xpath-description'>
   <p>It is common to want to use predicates on XML response bodies, but annoying to treat the XML as
     simple text with many of the predicates.  mountebank uses the <code>xpath</code> predicate parameter
     to narrow the scope of the predicate value to a value matched by the xpath selector.</p>
@@ -376,7 +376,7 @@
   <p class='info-icon'>More information: <a href='/docs/api/xpath'>xpath</a></p>
 </div>
 
-<div id='imposter-stubs-predicates-inject-description'>
+<div id='imposter-stubs-predicates-1-inject-description'>
   <p>When none of the built-in predicates are sufficient, mountebank allows you to script the
     predicate.  The injected function accepts the following parameters:</p>
 

--- a/src/views/docs/api/contracts/imposter.ejs
+++ b/src/views/docs/api/contracts/imposter.ejs
@@ -104,23 +104,23 @@
       ],
 <span id='imposter-stubs-predicates'><%- indent(6) %>&quot;predicates&quot;: [</span>
         {
-<span id='imposter-stubs-predicates-equals'><%- indent(10) %>&quot;equals&quot;: {
-            &quot;body&quot;: &quot;value&quot;,</span>
-<span id='imposter-stubs-predicates-equals-caseSensitive'><%- indent(12) %>&quot;caseSensitive&quot;: true,</span>
-<span id='imposter-stubs-predicates-equals-except'><%- indent(12) %>&quot;except&quot;: &quot;^The &quot;,</span>
-<span id='imposter-stubs-predicates-equals-jsonpath'><%- indent(12) %>&quot;jsonpath&quot;: {
-              &quot;selector&quot;: &quot;$..book&quot;
-            },</span>
-<span id='imposter-stubs-predicates-equals-xpath'><%- indent(12) %>&quot;xpath&quot;: {
-              &quot;selector&quot;: &quot;//book/@title&quot;,
-              &quot;ns&quot;: {
-                &quot;isbn&quot;: &quot;http://schemas.isbn.org/ns/1999/basic.dtd&quot;
-              }</span>
-            }
+<span id='imposter-stubs-predicates-0-equals'><%- indent(10) %>&quot;equals&quot;: {
+            &quot;body&quot;: &quot;value&quot;
+          },</span>
+<span id='imposter-stubs-predicates-0-caseSensitive'><%- indent(10) %>&quot;caseSensitive&quot;: true,</span>
+<span id='imposter-stubs-predicates-0-except'><%- indent(10) %>&quot;except&quot;: &quot;^The &quot;,</span>
+<span id='imposter-stubs-predicates-0-jsonpath'><%- indent(10) %>&quot;jsonpath&quot;: {
+            &quot;selector&quot;: &quot;$..book&quot;
+          },</span>
+<span id='imposter-stubs-predicates-0-xpath'><%- indent(10) %>&quot;xpath&quot;: {
+            &quot;selector&quot;: &quot;//book/@title&quot;,
+            &quot;ns&quot;: {
+              &quot;isbn&quot;: &quot;http://schemas.isbn.org/ns/1999/basic.dtd&quot;
+            }</span>
           }
         },
         {
-<span id='imposter-stubs-predicates-inject'><%- indent(8) %>&quot;inject&quot;: &quot;function (config) { return config.request.body.length &lt; 100; }&quot;</span>
+<span id='imposter-stubs-predicates-1-inject'><%- indent(10) %>&quot;inject&quot;: &quot;function (config) { return config.request.body.length &lt; 100; }&quot;</span>
         }
       ],
 <span id='imposter-stubs-matches' class='response'><%- indent(6) %>&quot;matches&quot;: [


### PR DESCRIPTION
This tripped me up for over half a day today. In the `imposter` contract docs, currently the `imposter.stubs[0].predicates` array is 

```json
"predicates": [
  {
    "equals": {
      "body": "value",
      "caseSensitive": true,
      "except": "^The ",
      "jsonpath": {
        "selector": "$..book"
       },
       "xpath": {
          "selector": "//book/@title",
          "ns": {
            "isbn": "http://schemas.isbn.org/ns/1999/basic.dtd"
         }
       }
     }
  },
  {
  "inject": "function (config) { return config.request.body.length < 100; }"
  }
]
```
which is obviously valid JSON, but it doesn't actually fulfill the contract for `predicates` - the parameters need to live at the same level as the operator object to be honored. This fixes (or should, anyway...I have no idea how to test it) the docs to show the correct structure:

```json
"predicates": [
  {
    "equals": {
      "body": "value",
    },
    "caseSensitive": true,
    "except": "^The ",
    "jsonpath": {
      "selector": "$..book"
    },
    "xpath": {
      "selector": "//book/@title",
      "ns": {
        "isbn": "http://schemas.isbn.org/ns/1999/basic.dtd"
      }
    }
  },
  {
    "inject": "function (config) { return config.request.body.length < 100; }"
  }
]
```
