### PR TITLE
chore: Bump xmldom to 0.8.0

### DIFF
--- a/mbTest/package-lock.json
+++ b/mbTest/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
+                "@xmldom/xmldom": "0.8.0",
                 "express": "4.17.1",
                 "fs-extra": "10.0.0",
                 "hpagent": "0.1.1",
@@ -20,7 +21,6 @@
                 "nodemailer": "6.6.3",
                 "safe-stable-stringify": "1.1.1",
                 "w3cjs": "0.4.0",
-                "xmldom": "0.6.0",
                 "xpath": "0.0.32"
             },
             "engines": {
@@ -28,10 +28,11 @@
             }
         },
         "..": {
-            "version": "2.5.0",
+            "version": "2.6.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
+                "@xmldom/xmldom": "0.8.0",
                 "cors": "2.8.5",
                 "csv-parse": "4.16.3",
                 "ejs": "3.1.6",
@@ -50,7 +51,6 @@
                 "safe-stable-stringify": "1.1.1",
                 "smtp-server": "3.9.0",
                 "winston": "3.3.3",
-                "xmldom": "0.6.0",
                 "xpath": "0.0.32",
                 "yargs": "17.1.1"
             },
@@ -338,14 +338,6 @@
                 "tlds": "bin.js"
             }
         },
-        "../node_modules/xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "../node_modules/yargs": {
             "version": "17.1.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
@@ -375,6 +367,14 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+            "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/abab": {
             "version": "2.0.5",
@@ -3630,14 +3630,6 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
-        "node_modules/xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/xpath": {
             "version": "0.0.32",
             "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
@@ -3787,6 +3779,11 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+        },
+        "@xmldom/xmldom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+            "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg=="
         },
         "abab": {
             "version": "2.0.5",
@@ -5211,6 +5208,7 @@
         "mountebank": {
             "version": "file:..",
             "requires": {
+                "@xmldom/xmldom": "0.8.0",
                 "cors": "2.8.5",
                 "coveralls": "3.1.1",
                 "csv-parse": "4.16.3",
@@ -5242,7 +5240,6 @@
                 "snyk": "1.705.0",
                 "w3cjs": "0.4.0",
                 "winston": "3.3.3",
-                "xmldom": "0.6.0",
                 "xpath": "0.0.32",
                 "yargs": "17.1.1"
             },
@@ -5440,11 +5437,6 @@
                     "version": "1.221.1",
                     "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.221.1.tgz",
                     "integrity": "sha512-N1Afn/SLeOQRpxMwHBuNFJ3GvGrdtY4XPXKPFcx8he0U9Jg9ZkvTKE1k3jQDtCmlFn44UxjVtouF6PT4rEGd3Q=="
-                },
-                "xmldom": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-                    "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
                 },
                 "yargs": {
                     "version": "17.1.1",
@@ -6579,11 +6571,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-        },
-        "xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
         },
         "xpath": {
             "version": "0.0.32",

--- a/mbTest/package.json
+++ b/mbTest/package.json
@@ -23,6 +23,7 @@
         "airplane": "MB_AIRPLANE_MODE=true npm test"
     },
     "dependencies": {
+        "@xmldom/xmldom": "0.8.0",
         "express": "4.17.1",
         "fs-extra": "10.0.0",
         "hpagent": "0.1.1",
@@ -34,7 +35,6 @@
         "nodemailer": "6.6.3",
         "safe-stable-stringify": "1.1.1",
         "w3cjs": "0.4.0",
-        "xmldom": "0.6.0",
         "xpath": "0.0.32"
     },
     "engines": {

--- a/mbTest/web/feedTest.js
+++ b/mbTest/web/feedTest.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
     api = require('../api').create(),
     httpClient = require('../baseHttpClient').create('http'),
     xpath = require('xpath'),
-    DOMParser = require('xmldom').DOMParser,
+    DOMParser = require('@xmldom/xmldom').DOMParser,
     timeout = parseInt(process.env.MB_SLOW_TEST_TIMEOUT || 3000);
 
 function entryCount (body) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,6 +917,11 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+      "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -10718,11 +10723,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
       "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "service virtualization"
   ],
   "dependencies": {
+    "@xmldom/xmldom": "0.8.0",
     "cors": "2.8.5",
     "csv-parse": "4.16.3",
     "ejs": "3.1.6",
@@ -71,7 +72,6 @@
     "safe-stable-stringify": "1.1.1",
     "smtp-server": "3.9.0",
     "winston": "3.3.3",
-    "xmldom": "0.6.0",
     "xpath": "0.0.32",
     "yargs": "17.1.1"
   },

--- a/src/models/xpath.js
+++ b/src/models/xpath.js
@@ -51,7 +51,7 @@ function nodeValue (node) {
  */
 function select (selector, ns, possibleXML, logger) {
     const xpath = require('xpath'),
-        DOMParser = require('xmldom').DOMParser,
+        DOMParser = require('@xmldom/xmldom').DOMParser,
         parser = new DOMParser({
             errorHandler: (level, message) => {
                 const warn = (logger || {}).warn || (() => {});


### PR DESCRIPTION
Switching from package `xmldom` to `@xmldom/xmldom`, which resolves the security issue present in latest xmldom version 0.6.0:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q

The reason is that the maintainers were forced to switch to a scoped package since 0.7.0:
 https://github.com/xmldom/xmldom/issues/271

No matter what version of node I used to try and run the normal `npm install`, I always received a warning about either old package lock file format or newer lock file version format.
So to avoid to many unrelated changes, I disabled the `postinstall` step locally and installed the root level using node v12 and the `mbTest` folder using node v16.
- When running the `npm run test` on the root level using node v12, there is a single failing test, but running them with node v16 works.So let's see what happens on CircleCI.
- When running `cb mbTest && npm run test` (using node 16) The first listed test fails. When adding `MB_AIRPLANE_MODE=true` there are quite a bunch of tests failing... not sure if this is really related to the xmldom update.

I'm happy to fix any regression we introduced, I just need help to understand how exactly the xmldom upgrade influences the failing test(s).

I'm one of the xmldom maintainers. Don't hesitate to ask me questions.


<details>
<summary>Changes in xmldom since 0.6.0</summary>
## [0.8.0](https://github.com/xmldom/xmldom/compare/0.7.5...0.8.0)

### Fixed
- Normalize all line endings according to XML specs [1.0](https://w3.org/TR/xml/#sec-line-ends) and [1.1](https://www.w3.org/TR/xml11/#sec-line-ends) \
  BREAKING CHANGE: Certain combination of line break characters are normalized to a single `\n` before parsing takes place and will no longer be preserved.
  - [`#303`](https://github.com/xmldom/xmldom/issues/303) / [`#307`](https://github.com/xmldom/xmldom/pull/307)
  - [`#49`](https://github.com/xmldom/xmldom/issues/49), [`#97`](https://github.com/xmldom/xmldom/issues/97), [`#324`](https://github.com/xmldom/xmldom/issues/324) / [`#314`](https://github.com/xmldom/xmldom/pull/314)
- XMLSerializer: Preserve whitespace character references [`#284`](https://github.com/xmldom/xmldom/issues/284) / [`#310`](https://github.com/xmldom/xmldom/pull/310) \
  BREAKING CHANGE: If you relied on the not spec compliant preservation of literal `\t`, `\n` or `\r` in **attribute values**.
  To preserve those you will have to create XML that instead contains the correct numerical (or hexadecimal) equivalent (e.g. `&#x9;`, `&#xA;`, `&#xD;`).
- Drop deprecated exports `DOMImplementation` and `XMLSerializer` from `lib/dom-parser.js` [#53](https://github.com/xmldom/xmldom/issues/53) / [`#309`](https://github.com/xmldom/xmldom/pull/309)
  BREAKING CHANGE: Use the one provided by the main package export.
- dom: Remove all links as part of `removeChild` [`#343`](https://github.com/xmldom/xmldom/issues/343) / [`#355`](https://github.com/xmldom/xmldom/pull/355)

### Chore
- ci: Restore latest tested node version to 16.x [`#325`](https://github.com/xmldom/xmldom/pull/325)
- ci: Split test and lint steps into jobs [`#111`](https://github.com/xmldom/xmldom/issues/111) / [`#304`](https://github.com/xmldom/xmldom/pull/304)
- Pinned and updated devDependencies

Thank you [@marrus-sh](https://github.com/marrus-sh), [@victorandree](https://github.com/victorandree), [@mdierolf](https://github.com/mdierolf), [@tsabbay](https://github.com/tsabbay), [@fatihpense](https://github.com/fatihpense) for your contributions

## 0.7.5

[Commits](https://github.com/xmldom/xmldom/compare/0.7.4...0.7.5)

### Fixes:

- Preserve default namespace when serializing [`#319`](https://github.com/xmldom/xmldom/issues/319) / [`#321`](https://github.com/xmldom/xmldom/pull/321)
  Thank you [@lupestro](https://github.com/lupestro)

## 0.7.4

[Commits](https://github.com/xmldom/xmldom/compare/0.7.3...0.7.4)

### Fixes:

- Restore ability to parse `__prototype__` attributes [`#315`](https://github.com/xmldom/xmldom/pull/315)
  Thank you [@dsimsonOMF](https://github.com/dsimsonOMF)

## 0.7.3

[Commits](https://github.com/xmldom/xmldom/compare/0.7.2...0.7.3)

### Fixes:

- Add doctype when parsing from string [`#277`](https://github.com/xmldom/xmldom/issues/277) / [`#301`](https://github.com/xmldom/xmldom/pull/301)
- Correct typo in error message [`#294`](https://github.com/xmldom/xmldom/pull/294)
  Thank you [@rrthomas](https://github.com/rrthomas)

### Refactor:

- Improve exports & require statements, new main package entry [`#233`](https://github.com/xmldom/xmldom/pull/233)

### Docs:

- Fix Stryker badge [`#298`](https://github.com/xmldom/xmldom/pull/298)
- Fix link to help-wanted issues [`#299`](https://github.com/xmldom/xmldom/pull/299)

### Chore:

- Execute stryker:dry-run on branches [`#302`](https://github.com/xmldom/xmldom/pull/302)
- Fix stryker config [`#300`](https://github.com/xmldom/xmldom/pull/300)
- Split test and lint scripts [`#297`](https://github.com/xmldom/xmldom/pull/297)
- Switch to stryker dashboard owned by org [`#292`](https://github.com/xmldom/xmldom/pull/292)

## 0.7.2

[Commits](https://github.com/xmldom/xmldom/compare/0.7.1...0.7.2)

### Fixes:

- Types: Add index.d.ts to packaged files [`#288`](https://github.com/xmldom/xmldom/pull/288)
  Thank you [@forty](https://github.com/forty)

## 0.7.1

[Commits](https://github.com/xmldom/xmldom/compare/0.7.0...0.7.1)

### Fixes:

- Types: Copy types from DefinitelyTyped [`#283`](https://github.com/xmldom/xmldom/pull/283)
  Thank you [@kachkaev](https://github.com/kachkaev)

### Chore:
- package.json: remove author, maintainers, etc. [`#279`](https://github.com/xmldom/xmldom/pull/279)

## 0.7.0 

[Commits](https://github.com/xmldom/xmldom/compare/0.6.0...0.7.0)

Due to [`#271`](https://github.com/xmldom/xmldom/issue/271) this version was published as
- unscoped `xmldom` package to github (git tags [`0.7.0`](https://github.com/xmldom/xmldom/tree/0.7.0) and [`0.7.0+unscoped`](https://github.com/xmldom/xmldom/tree/0.7.0%2Bunscoped))
- scoped `@xmldom/xmldom` package to npm (git tag `0.7.0+scoped`)
For more details look at [`#278`](https://github.com/xmldom/xmldom/pull/278#issuecomment-902172483)

### Fixes:

- Security: Misinterpretation of malicious XML input [`CVE-2021-32796`](https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q)
- Implement `Document.getElementsByClassName` as specified [`#213`](https://github.com/xmldom/xmldom/pull/213), thank you [@ChALkeR](https://github.com/ChALkeR)
- Inherit namespace prefix from parent when required [`#268`](https://github.com/xmldom/xmldom/pull/268)
- Handle whitespace in closing tags [`#267`](https://github.com/xmldom/xmldom/pull/267)
- Update `DOMImplementation` according to recent specs [`#210`](https://github.com/xmldom/xmldom/pull/210)  
  BREAKING CHANGE: Only if you "passed features to be marked as available as a constructor arguments" and expected it to "magically work".
- No longer serializes any namespaces with an empty URI [`#244`](https://github.com/xmldom/xmldom/pull/244)   
  (related to [`#168`](https://github.com/xmldom/xmldom/pull/168) released in 0.6.0)  
  BREAKING CHANGE: Only if you rely on ["unsetting" a namespace prefix](https://github.com/xmldom/xmldom/pull/168#issuecomment-886984994) by setting it to an empty string 
- Set `localName` as part of `Document.createElement` [`#229`](https://github.com/xmldom/xmldom/pull/229), thank you [@rrthomas](https://github.com/rrthomas)

### CI

- We are now additionally running tests against node v16
- Stryker tests on the master branch now run against node v14

### Docs

- Describe relations with and between specs: [`#211`](https://github.com/xmldom/xmldom/pull/211), [`#247`](https://github.com/xmldom/xmldom/pull/247)
</details>