### PR TITLE
add custom network management protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ At the moment, the following protocols are implemented, either directly in the t
 * grpc
 * websockets
 * graphql
+* snmp
+* telnet
+* ssh
+* netconf
 
 mountebank supports mock verification, stubbing with advanced predicates, JavaScript injection,
 and record-playback through proxying.

--- a/src/views/_header.ejs
+++ b/src/views/_header.ejs
@@ -109,6 +109,10 @@
             <li><a href='https://github.com/cbrz/mountebank-grpc'>grpc</a></li>
             <li><a href='https://github.com/vamsib/mountebank-ws'>websockets</a></li>
             <li><a href='https://github.com/bashj79/mb-graphql'>graphql</a></li>
+            <li><a href='https://github.com/telekom/mb-netmgmt'>snmp</a></li>
+            <li><a href='https://github.com/telekom/mb-netmgmt'>telnet</a></li>
+            <li><a href='https://github.com/telekom/mb-netmgmt'>ssh</a></li>
+            <li><a href='https://github.com/telekom/mb-netmgmt'>netconf</a></li>
             <li><a href='/docs/protocols/custom'>create your own</a></li>
           </ul>
 


### PR DESCRIPTION
We just open-sourced our custom protocol implementation of SNMP, Telnet, SSH and NETCONF which we are using internally for testing Network Management Software