### PR TITLE
Update docker cmd-line in Getting Started

### DIFF
--- a/src/views/docs/gettingStarted.ejs
+++ b/src/views/docs/gettingStarted.ejs
@@ -23,7 +23,7 @@ case you can run mountebank using the <code>npx mb</code> command.</p>
 <p>Alternatively, you can download the Docker image and run:</p>
 
 <pre><code>docker pull bbyars/mountebank:<%= version %>
-docker run --rm -p 2525:2525 -p 8080:8080 bbyars/mountebank:<%= version %> mb start --configfile imposters.ejs</code></pre>
+docker run --rm -p 2525:2525 -p 4545:4545 -p 5555:5555 bbyars/mountebank:<%= version %> mb start </code></pre>
 
 <p><b>Use:</b></p>
 


### PR DESCRIPTION
The example imposters in the Getting Started page use ports `4545` and `5555` . The docker container is not exposing them but `8080`. AFAIU `8080` is not used in anyway, and only the controller at `2525` needs to be additionally exposed.

The file `imposters.ejs` does not seem to exist in the container, but I believe it is not necessary for these examples either, so I am removing it.
For reference, the error was:
```
$ docker run --rm -p 2525:2525 -p 8080:8080 bbyars/mountebank:2.6.0 mb start --configfile imposters.ejs
info: [mb:2525] mountebank v2.6.0 now taking orders - point your browser to http://localhost:2525/ for help
No such file: imposters.ejs
Error: ENOENT: no such file or directory, open 'imposters.ejs'
    at Object.openSync (fs.js:497:3)
    at Object.readFileSync (fs.js:393:35)
    at Object.load (/usr/local/lib/node_modules/mountebank/node_modules/mountebank-formatters/src/default.js:41:29)
    at Object.load (/usr/local/lib/node_modules/mountebank/node_modules/mountebank-formatters/src/index.js:13:43)
    at Object.loadConfig (/usr/local/lib/node_modules/mountebank/src/cli/api.js:70:43)
    at Object.start (/usr/local/lib/node_modules/mountebank/bin/mb:48:23)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'imposters.ejs'
}
```