### PR TITLE
ISSUE-652: Add docker multi-arch support

### DIFF
--- a/scripts/publishDocker
+++ b/scripts/publishDocker
@@ -9,7 +9,7 @@ if [ "$MB_RELEASE" = "true" ]; then
 fi
 
 cd dist/mountebank
-DOCKER_BUILDKIT=1 docker build -t bbyars/mountebank:$VERSION -t bbyars/mountebank:$TAG .
-docker login -u $DOCKER_USER -p "$DOCKER_PASSWORD"
+DOCKER_BUILDKIT=1 docker buildx build --platform=linux/arm64,linux/amd64 --no-cache --tag bbyars/mountebank:$VERSION --tag bbyars/mountebank:$TAG --push .
+docker login --username $DOCKER_USER --password "$DOCKER_PASSWORD"
 docker push bbyars/mountebank:$VERSION
 docker push bbyars/mountebank:$TAG


### PR DESCRIPTION
ISSUE-652: Add docker multi-arch support and add arm64 as target architecture

* `--push` is needed to fix the following waring: `WARNING: No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load`
* Command options written out to increase readability
* Add `platform` Option to support arm64 architecture 

I tested the feature and execute the `publishDocker` script and uploaded the result to my personal docker hub repository. Please check this to verify that the implementation works: https://hub.docker.com/r/ezienecker/mountebank/tags