### PR TITLE
Add optional support for validating client certificates

### DIFF
--- a/src/models/https/httpsServer.js
+++ b/src/models/https/httpsServer.js
@@ -24,7 +24,7 @@ function createBaseServer (options) {
             mutualAuth: metadata.mutualAuth,
             rejectUnauthorized: metadata.rejectUnauthorized,
             ca: metadata.ca,
-            requestCert: !!metadata.rejectUnauthorized
+            requestCert: metadata.mutualAuth && metadata.rejectUnauthorized
         },
         createNodeServer = () => require('https').createServer(config);
 

--- a/src/models/https/httpsServer.js
+++ b/src/models/https/httpsServer.js
@@ -11,7 +11,9 @@ function createBaseServer (options) {
         metadata = {
             key: options.key || fs.readFileSync(path.join(__dirname, '/cert/mb-key.pem'), 'utf8'),
             cert: options.cert || fs.readFileSync(path.join(__dirname, '/cert/mb-cert.pem'), 'utf8'),
-            mutualAuth: Boolean(options.mutualAuth)
+            mutualAuth: Boolean(options.mutualAuth),
+            rejectUnauthorized: options.rejectUnauthorized || false,
+            ca: options.ca || null
         },
         // client certs will not reject the request.  It does set the request.client.authorized variable
         // to false for all self-signed certs; use rejectUnauthorized: true and a ca: field set to an array
@@ -19,8 +21,10 @@ function createBaseServer (options) {
         config = {
             key: metadata.key,
             cert: metadata.cert,
-            mutualAuth: metadata.cert,
-            rejectUnauthorized: false
+            mutualAuth: metadata.mutualAuth,
+            rejectUnauthorized: metadata.rejectUnauthorized,
+            ca: metadata.ca,
+            requestCert: !!metadata.rejectUnauthorized
         },
         createNodeServer = () => require('https').createServer(config);
 

--- a/src/views/docs/protocols/https.ejs
+++ b/src/views/docs/protocols/https.ejs
@@ -113,6 +113,21 @@ switch in <code>curl</code>).  Alternatively, you may pass in the key pair yours
     <td>false</td>
     <td>If true, mountebank will allow all CORS preflight requests on the imposter.</td>
   </tr>
+  <tr>
+    <td><code>rejectUnauthorized</code></td>
+    <td>boolean</td>
+    <td>No</td>
+    <td>false</td>
+    <td>If true, mountebank will validate the certificate against the list of supplied CAs.</td>
+  </tr>
+  <tr>
+    <td><code>ca</code></td>
+    <td>Array of PEM-formatted certificates</td>
+    <td>No</td>
+    <td>null</td>
+    <td>Use when setting <code>rejectUnauthorized</code> to true to provide a list of certificates to validate against.
+        When <code>rejectUnauthorized</code> is true and <code>mutualAuth</code> is true, mountebank will request a client certificate.</td>
+  </tr>
 </table>
 
 <p>See the <a href='/docs/protocols/http'>http</a> page for examples.  Just be sure


### PR DESCRIPTION
Added optional support for validating client certificates when `mutualAuth `is enabled.  There are two new settings when configuring an HTTPS imposter: `rejectUnauthorized` and `ca`.  When both mutualAuth and rejectUnauthorized are true, the HTTPS server will request client certificates and validate them against the list of certificates provided in the `ca `setting.