### PR TITLE
Add optional API Key security to mb api

### DIFF
--- a/src/cli/api.js
+++ b/src/cli/api.js
@@ -12,8 +12,13 @@ function curl (options, method, path, body) {
                     'Content-Type': 'application/json',
                     Connection: 'close'
                 }
-            },
-            request = http.request(requestOptions, response => {
+            };
+
+        if (options.apikey) {
+            requestOptions.headers['x-api-key'] = options.apikey;
+        }
+        
+        const request = http.request(requestOptions, response => {
                 response.body = '';
                 response.setEncoding('utf8');
                 response.on('data', chunk => { response.body += chunk; });

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -171,6 +171,12 @@ const fs = require('fs-extra'),
             default: false,
             type: 'boolean',
             global: false
+        },
+        apikey: {
+            description: 'An optional API key. When provided, a user must add an API key to the header.',
+            default: null,
+            type: 'string',
+            global: false
         }
     },
     startOptions = {
@@ -195,7 +201,8 @@ const fs = require('fs-extra'),
         heroku: options.heroku,
         protofile: options.protofile,
         origin: options.origin,
-        rcfile: options.rcfile
+        rcfile: options.rcfile,
+        apikey: options.apikey
     },
     argv = yargs
         .usage('Usage: mb [command=start] [options...]')

--- a/src/mountebank.js
+++ b/src/mountebank.js
@@ -57,6 +57,7 @@ async function createApp (options) {
     prometheus.collectDefaultMetrics({ prefix: 'mb_' });
 
     app.use(middleware.useAbsoluteUrls(options.port));
+    app.use(middleware.validateApiKey(options.apikey, logger));
     app.use(middleware.logger(logger, ':method :url'));
     app.use(middleware.globals({ heroku: options.heroku, port: options.port, version: thisPackage.version }));
     app.use(middleware.defaultIEtoHTML);

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -50,5 +50,6 @@ module.exports = {
     CommunicationError: createWithMessage('communication', 'Error communicating with mountebank'),
     ProtocolError: create('cannot start server'),
     DatabaseError: create('corrupted database'),
+    UnauthorizedError: createWithMessage('unauthorized', 'If you set the apiKey option, make sure you are sending the correct apiKey in the x-api-key header.'),
     details
 };

--- a/src/util/middleware.js
+++ b/src/util/middleware.js
@@ -220,4 +220,40 @@ function json (log) {
     };
 }
 
-module.exports = { useAbsoluteUrls, createImposterValidator, logger, globals, defaultIEtoHTML, json };
+function validateApiKey (expectedApiKey, log) {
+    return function (request, response, next) {
+        if (!expectedApiKey)
+        {
+            next();
+            return;
+        }
+
+        const errors = require('./errors');
+        
+        if (!request.headers['x-api-key']) {
+            log.error('The x-api-key header is required but was not provided');
+            response.statusCode = 401;
+            response.send({
+                errors: [errors.UnauthorizedError()]
+            });
+            return;
+        }
+
+        var crypto = require('crypto');
+        const hash = crypto.createHash('sha512');
+        if (crypto.timingSafeEqual(
+            hash.copy().update(request.headers['x-api-key']).digest(),
+            hash.copy().update(expectedApiKey).digest()
+        )) {
+            next();
+        } else {
+            log.error('The x-api-key header value does not match the expected API key');
+            response.statusCode = 401;
+            response.send({
+                errors: [errors.UnauthorizedError()]
+            });
+        }        
+    }
+}
+
+module.exports = { useAbsoluteUrls, createImposterValidator, logger, globals, defaultIEtoHTML, json, validateApiKey };

--- a/src/views/docs/cli/start.ejs
+++ b/src/views/docs/cli/start.ejs
@@ -205,6 +205,15 @@ official site only contains the latest docs. The following options are available
     <td><code>mb.pid</code></td>
   </tr>
   <tr>
+    <td><code>--apikey myapikey</code></td>
+    <td>
+      An optional API key. When this is provided, 
+      the Mountebank API will require that the x-api-key 
+      header be supplied with a matching key.
+    </td>
+    <td><code>null</code></td>
+  </tr>
+  <tr>
     <td><code>--version</code></td>
     <td>Print the version out to the console and exit.</td>
     <td><code>N/A</code></td>

--- a/test/util/middlewareTest.js
+++ b/test/util/middlewareTest.js
@@ -330,4 +330,48 @@ describe('middleware', function () {
             assert.strictEqual(request.headers.accept, 'accept/any, application/json');
         });
     });
+
+    describe('#validateApiKey', function() {
+        it('should call next when expectedApiKey empty', function() {
+            const log = { error: mock() },
+                middlewareFn = middleware.validateApiKey('', log);
+            request = { method: 'METHOD', url: 'URL', headers: { accept: '' } };
+
+            middlewareFn(request, response, next);
+
+            assert(next.wasCalled());
+        });
+
+        it('should call next when expectedApiKey is set and matches x-api-key header', function() {
+            const log = { error: mock() },
+                middlewareFn = middleware.validateApiKey('abc123', log);
+            request = { method: 'METHOD', url: 'URL', headers: { accept: '', 'x-api-key': 'abc123' } };
+
+            middlewareFn(request, response, next);
+
+            assert(next.wasCalled());
+        });
+
+        it('should set response to 401 when x-api-key header is incorrect', function() {
+            const log = { error: mock() },
+                middlewareFn = middleware.validateApiKey('abc123', log);
+            request = { method: 'METHOD', url: 'URL', headers: { accept: '', 'x-api-key': 'abcxyz' } };
+
+            middlewareFn(request, response, next);
+
+            assert(!(next.wasCalled()));
+            assert.strictEqual(response.statusCode, 401);
+        });
+
+        it('should set response to 401 when x-api-key header is missing', function() {
+            const log = { error: mock() },
+                middlewareFn = middleware.validateApiKey('abc123', log);
+            request = { method: 'METHOD', url: 'URL', headers: { accept: '' } };
+
+            middlewareFn(request, response, next);
+
+            assert(!(next.wasCalled()));
+            assert.strictEqual(response.statusCode, 401);
+        });
+    })
 });


### PR DESCRIPTION
This PR adds an optional startup option named "apikey".  If the API Key is set, calls to the Mountebank API will require a matching value set in the x-api-key header, otherwise an unauthorized response will be returned.  This does not affect calls to imposters.

`mb start --apikey abc123`