### PR TITLE
Ensure file system writes are synchronous

### DIFF
--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -140,7 +140,7 @@ function create (config, logger) {
 
     async function writeFile (filepath, obj) {
         await ensureDir(filepath);
-        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2), writeFileOptions);
+        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2));
     }
 
     function tryParse (maybeJSON, filepath) {

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -112,6 +112,15 @@ const
     };
 
 /**
+* Ensure writes are synchronous. This ensures the file is written to the underlying storage.
+* This is important when multiple instances of Mountebank are running and using an NFS as it ensures
+* consistent reads across the instances.
+*/
+const writeFileOptions = {
+    flag: 'rs+'
+};
+
+/**
  * Creates the repository
  * @param {Object} config - The database configuration
  * @param {String} config.datadir - The database directory
@@ -131,7 +140,7 @@ function create (config, logger) {
 
     async function writeFile (filepath, obj) {
         await ensureDir(filepath);
-        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2));
+        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2), writeFileOptions);
     }
 
     function tryParse (maybeJSON, filepath) {

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -131,7 +131,9 @@ function create (config, logger) {
 
     async function writeFile (filepath, obj) {
         await ensureDir(filepath);
-        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2));
+        await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2), {
+            flag: 'rs+'
+        });
     }
 
     function tryParse (maybeJSON, filepath) {

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -129,10 +129,13 @@ function create (config, logger) {
         await fsExtra.ensureDir(dir);
     }
 
+    async function ensureFile (filepath) {
+        fsExtra.close(await fsExtra.open(filepath, 'as'));
+    }
+
     async function writeFile (filepath, obj) {
         await ensureDir(filepath);
-
-        await fsExtra.ensureFile(filepath);
+        await ensureFile(filepath);
         await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2), {
             flag: 'rs+'
         });

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -112,15 +112,6 @@ const
     };
 
 /**
-* Ensure writes are synchronous. This ensures the file is written to the underlying storage.
-* This is important when multiple instances of Mountebank are running and using an NFS as it ensures
-* consistent reads across the instances.
-*/
-const writeFileOptions = {
-    flag: 'rs+'
-};
-
-/**
  * Creates the repository
  * @param {Object} config - The database configuration
  * @param {String} config.datadir - The database directory

--- a/src/models/filesystemBackedImpostersRepository.js
+++ b/src/models/filesystemBackedImpostersRepository.js
@@ -131,6 +131,8 @@ function create (config, logger) {
 
     async function writeFile (filepath, obj) {
         await ensureDir(filepath);
+
+        await fsExtra.ensureFile(filepath);
         await fsExtra.writeFile(filepath, JSON.stringify(obj, null, 2), {
             flag: 'rs+'
         });


### PR DESCRIPTION
We have encountered issues running Mountebank in a load balanced setup. The intent is that we can scale to multiple instances to support load tests we are running. We are using Mountebank to isolate the test to just the services owned by our team.

This is implemented by setting the `datadir` and pointing it to an AWS EFS volume we have attached to the Mountebank container. As part of the load test setup, we create a set of imposters. What we are noticing that once the load test runs is that we get errors like this consistently under high load:

```Corrupted database: missing file /app/efs/8080/stubs/1666866944467-1-93/meta.json```

There appears to be no evidence of errors in the logs when the imposters are initially created, so what I believe is happening is that as asynchronous writes are being used, some files are cached on the host that created them before being flushed to the underlying storage in EFS.

This PR ensures that files are written using the [file system flags](https://nodejs.org/api/fs.html#file-system-flags) that ensure synchronous calls are made which guarantees that the updates are pushed to the underlying volume storage. The downside to this is that it makes writes slower. This could be made configurable if required, but I've left this out for now as I'm not sure it's required.
