### PR TITLE
Check that http URLs don't have a path in proxy.to

### DIFF
--- a/src/models/dryRunValidator.js
+++ b/src/models/dryRunValidator.js
@@ -76,7 +76,16 @@ function create (options) {
         // We can get a better test (running behaviors on proxied result) if the protocol gives
         // us a testProxyResult
         if (options.testProxyResponse) {
-            const dryRunProxy = { to: () => Promise.resolve(options.testProxyResponse) };
+            const dryRunProxy = { to: proxyTo => {
+                if (proxyTo === undefined) {
+                    throw exceptions.ValidationError('Missing to');
+                }
+                const url = new URL(proxyTo);
+                if ((url.protocol === 'http' || url.protocol === 'https') && url.pathname !== '/') {
+                    throw exceptions.ValidationError(`proxy.to must not contain a path '${url.pathname}'`);
+                }
+                return Promise.resolve(options.testProxyResponse);
+            } };
             return responseResolver.create(stubRepository, dryRunProxy);
         }
         else {


### PR DESCRIPTION
I spent longer than I'd like to admit debugging why my http proxy with a path was getting 404s. I finally saw in the docs that `proxy.to` is supposed to be a URL without a path. For future people like me who don't read the docs scrupulously enough, I wanted to add a warning or a failure on creating a proxy with a path.

This is my first stab at that. I'm guessing if we wanted to add something like this, we'd want to make it a warning in one release and then possibly make it an error in a followup release. Rather than guess at what upgrade experience we want, I decided to open a PR to discuss it.

I ran the tests before opening the PR and saw "http proxy stubs: should gracefully deal with bad urls" fail. Based on that, I'm guessing we don't want to disallow or warn on URLs with paths.

I still opened this as that surprises me a bit. As a user of the library, I'd much rather be told that my configuration is invalid when I create it than when I try to use it. Your thoughts on how to proceed if at all?