### PR TITLE
Add MountebankSwift to community extensions

### DIFF
--- a/src/views/docs/communityExtensions.ejs
+++ b/src/views/docs/communityExtensions.ejs
@@ -113,6 +113,11 @@ a pull request to this page and he will add it to the list below.</p>
         <td><a href='https://www.npmjs.com/package/@anev/ts-mountebank'>ts-mountebank</a></td>
         <td>Angela Evans</td>
     </tr>
+    <tr>
+        <td>Swift</td>
+        <td><a href='https://github.com/MountebankSwift/MountebankSwift/'>MountebankSwift</a></td>
+        <td>Teameh & Mat1th</td>
+    </tr>
 </table>
 
 <h1>Persistence Stores</h1>


### PR DESCRIPTION
It is really great to use Mountebank for UI Testing for Apple ecosystem apps using Swift code directly in Xcode. 

However there was no community package for Swift yet, so [@mat1th](https://github.com/mat1th) and I created one!