### PR TITLE
Fixing link to configFiles

### DIFF
--- a/src/views/docs/cli/start.ejs
+++ b/src/views/docs/cli/start.ejs
@@ -51,7 +51,7 @@ official site only contains the latest docs. The following options are available
   <tr>
     <td><code>--configfile imposters.ejs</code></td>
     <td>If present, mountebank will load the contents of the specified file.  See
-    <a href='#config-file'>below</a> for details.
+    <a href='#config-files'>below</a> for details.
 
     <p class='warning-icon'>If both the <code>datadir</code> and <code>configfile</code> options are
     used, mountebank will initially load all imposters from the <code>datadir</code> and then add all from


### PR DESCRIPTION
The link in the description of the --configfile option is missing an 's', it is linking to configFiles.ejs