### PR TITLE
Fix errors when matching with type number

### DIFF
--- a/mbTest/api/http/httpStubTest.js
+++ b/mbTest/api/http/httpStubTest.js
@@ -639,6 +639,111 @@ function merge (defaults, overrides) {
 
                 assert.strictEqual(response.body, 'Matched');
             });
+
+            it('should support matching request body with type number using contains', async function () {
+                const request = {
+                    port,
+                    protocol,
+                    stubs: [
+                        { predicates: [{ contains: { body: { number: 1 } } }], responses: [{ is: { body: 'Matched Exact Integer' } }]},
+                        { predicates: [{ contains: { body: { number: 2 } } }], responses: [{ is: { body: 'Matched Partial Integer' } }]},
+                        { predicates: [{ contains: { body: { number: 3.03 } } }], responses: [{ is: { body: 'Matched Exact Float' } }]},
+                        { predicates: [{ contains: { body: { number: 4.04 } } }], responses: [{ is: { body: 'Matched Partial Float' } }]},
+                        { predicates: [{ contains: { body: { number: -5 } } }], responses: [{ is: { body: 'Matched Exact Negative' } }]},
+                        { predicates: [{ contains: { body: { number: -6 } } }], responses: [{ is: { body: 'Matched Partial Negative' } }]}
+                    ]
+                };
+
+                await api.createImposter(request);
+
+                const matchedInteger = await client.post('/', '{ "number": 1 }', port);
+                const matchedPartialInteger = await client.post('/', '{ "number": 22 }', port);
+
+                const matchedExactFloat = await client.post('/', '{ "number": 3.03 }', port);
+                const matchedPartialFloat = await client.post('/', '{ "number": 44.04  }', port);
+
+                const matchedExactNegative = await client.post('/', '{ "number": -5 }', port);
+                const matchedPartialNegative = await client.post('/', '{ "number": -6.06 }', port);
+
+                assert.strictEqual(matchedInteger.body, 'Matched Exact Integer');
+                assert.strictEqual(matchedPartialInteger.body, 'Matched Partial Integer');
+
+                assert.strictEqual(matchedExactFloat.body, 'Matched Exact Float');
+                assert.strictEqual(matchedPartialFloat.body, 'Matched Partial Float');
+
+                assert.strictEqual(matchedExactNegative.body, 'Matched Exact Negative');
+                assert.strictEqual(matchedPartialNegative.body, 'Matched Partial Negative');
+            });
+
+            it('should support matching request body with type number using startsWith', async function () {
+                const request = {
+                    port,
+                    protocol,
+                    stubs: [
+                        { predicates: [{ startsWith: { body: { number: 1 } } }], responses: [{ is: { body: 'Matched Exact Integer' } }]},
+                        { predicates: [{ startsWith: { body: { number: 2 } } }], responses: [{ is: { body: 'Matched Partial Integer' } }]},
+                        { predicates: [{ startsWith: { body: { number: 3.03 } } }], responses: [{ is: { body: 'Matched Exact Float' } }]},
+                        { predicates: [{ startsWith: { body: { number: 44.0 } } }], responses: [{ is: { body: 'Matched Partial Float' } }]},
+                        { predicates: [{ startsWith: { body: { number: -5 } } }], responses: [{ is: { body: 'Matched Exact Negative' } }]},
+                        { predicates: [{ startsWith: { body: { number: -6 } } }], responses: [{ is: { body: 'Matched Partial Negative' } }]}
+                    ]
+                };
+
+                await api.createImposter(request);
+
+                const matchedInteger = await client.post('/', '{ "number": 1 }', port);
+                const matchedPartialInteger = await client.post('/', '{ "number": 21 }', port);
+
+                const matchedExactFloat = await client.post('/', '{ "number": 3.03 }', port);
+                const matchedPartialFloat = await client.post('/', '{ "number": 44.04  }', port);
+
+                const matchedExactNegative = await client.post('/', '{ "number": -5 }', port);
+                const matchedPartialNegative = await client.post('/', '{ "number": -6.06 }', port);
+
+                assert.strictEqual(matchedInteger.body, 'Matched Exact Integer');
+                assert.strictEqual(matchedPartialInteger.body, 'Matched Partial Integer');
+
+                assert.strictEqual(matchedExactFloat.body, 'Matched Exact Float');
+                assert.strictEqual(matchedPartialFloat.body, 'Matched Partial Float');
+
+                assert.strictEqual(matchedExactNegative.body, 'Matched Exact Negative');
+                assert.strictEqual(matchedPartialNegative.body, 'Matched Partial Negative');
+            });
+
+            it('should support matching request body with type number using endsWith', async function () {
+                const request = {
+                    port,
+                    protocol,
+                    stubs: [
+                        { predicates: [{ endsWith: { body: { number: 1 } } }], responses: [{ is: { body: 'Matched Exact Integer' } }]},
+                        { predicates: [{ endsWith: { body: { number: 2 } } }], responses: [{ is: { body: 'Matched Partial Integer' } }]},
+                        { predicates: [{ endsWith: { body: { number: 3.03 } } }], responses: [{ is: { body: 'Matched Exact Float' } }]},
+                        { predicates: [{ endsWith: { body: { number: 4.04 } } }], responses: [{ is: { body: 'Matched Partial Float' } }]},
+                        { predicates: [{ endsWith: { body: { number: -5 } } }], responses: [{ is: { body: 'Matched Exact Negative' } }]},
+                        { predicates: [{ endsWith: { body: { number: 6.06 } } }], responses: [{ is: { body: 'Matched Partial Negative' } }]}
+                    ]
+                };
+
+                await api.createImposter(request);
+
+                const matchedInteger = await client.post('/', '{ "number": 1 }', port);
+                const matchedPartialInteger = await client.post('/', '{ "number": 22 }', port);
+
+                const matchedExactFloat = await client.post('/', '{ "number": 3.03 }', port);
+                const matchedPartialFloat = await client.post('/', '{ "number": 44.04  }', port);
+
+                const matchedExactNegative = await client.post('/', '{ "number": -5 }', port);
+                const matchedPartialNegative = await client.post('/', '{ "number": -66.06 }', port);
+
+                assert.strictEqual(matchedInteger.body, 'Matched Exact Integer');
+                assert.strictEqual(matchedPartialInteger.body, 'Matched Partial Integer');
+
+                assert.strictEqual(matchedExactFloat.body, 'Matched Exact Float');
+                assert.strictEqual(matchedPartialFloat.body, 'Matched Partial Float');
+
+                assert.strictEqual(matchedExactNegative.body, 'Matched Exact Negative');
+                assert.strictEqual(matchedPartialNegative.body, 'Matched Partial Negative');
+            });
         });
     });
 });

--- a/src/models/predicates.js
+++ b/src/models/predicates.js
@@ -398,12 +398,33 @@ function toString (value) {
     }
 }
 
+function contains(actual, expected) {
+    if (typeof actual === 'string') {
+        return actual.indexOf(expected) >= 0;
+    }
+    return actual.toString().indexOf(expected) >= 0;
+}
+
+function startsWith(actual, expected) {
+    if (typeof actual === 'string') {
+        return actual.indexOf(expected) === 0;
+    }
+    return actual.toString().indexOf(expected) === 0;
+}
+
+function endsWith(actual, expected) {
+    if (typeof actual === 'string') {
+        return actual.indexOf(expected, actual.length - expected.length) >= 0;
+    }
+    return actual.toString().indexOf(expected, actual.length - expected.length) >= 0;
+}
+
 const predicates = {
     equals: create('equals', (expected, actual) => toString(expected) === toString(actual)),
     deepEquals,
-    contains: create('contains', (expected, actual) => actual.indexOf(expected) >= 0),
-    startsWith: create('startsWith', (expected, actual) => actual.indexOf(expected) === 0),
-    endsWith: create('endsWith', (expected, actual) => actual.indexOf(expected, actual.length - expected.length) >= 0),
+    contains: create('contains', (expected, actual) => contains(actual, expected)),
+    startsWith: create('startsWith', (expected, actual) => startsWith(actual, expected)),
+    endsWith: create('endsWith', (expected, actual) => endsWith(actual, expected)),
     matches,
     exists: create('exists', function (expected, actual) {
         return expected ? (typeof actual !== 'undefined' && actual !== '') : (typeof actual === 'undefined' || actual === '');


### PR DESCRIPTION
# Description
I encountered an error when creating a predicate that matches the request body with type number using `contains`, `startsWith`, or `endsWith`. For example, when creating a predicate for the API `/transfer-money` with an amount that starts with 200:
```
predicates = {
    startsWith: { amount: 200 }
}
```
Sending a request with an amount of 200.01 results in the following error:

```
{
    "errors": [
        {
            "message": "actual.indexOf is not a function",
            "name": "TypeError",
            "stack": "TypeError: actual.indexOf is not a function\n    at ..."
        }
    ]
}
```
![Screenshot 2567-05-17 at 19 37 17](https://github.com/bbyars/mountebank/assets/43701085/353277d9-e7cf-4c4a-96a3-480367f056bb)

# Modifications
I have created three new methods (`contains`, `startsWith`, `endsWith`) that check whether the actual type is a string. If it is not, the value is converted to a string before calling the `.indexOf` method.

However, I'm considering if it might be better to provide more understandable error messages, such as: 
```
Type not supported for this parameter {name}. Consider using equals or matches instead. 
```
Or maybe we could add features such as `lessThan` or `greaterThan` to support specific types of numbers. What do you think?