### PR TITLE
Add devcontainer configuration for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Mountebank - Node.js 18",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
I prefer to do my development in [devcontainers](https://containers.dev/) when possible to avoid having to manage dependencies on my local machine. Let me know if you're fine with me adding a configuration for this, otherwise I'll add it to the `.gitignore` and just have it set up on my local machine.