### PR TITLE
Imposter name detail page title

### DIFF
--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -121,8 +121,6 @@ module.exports = function (createBaseServer) {
         server.on('request', async (request, response) => {
             const clientName = helpers.socketName(request.socket);
 
-            logger.info(`${clientName} => ${request.method} ${request.url}`);
-
             try {
                 const simplifiedRequest = await httpRequest.createFrom(request);
                 let logMessage = `${clientName} => ${request.method} ${request.url}`;

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -122,7 +122,7 @@ module.exports = function (createBaseServer) {
             const clientName = helpers.socketName(request.socket);
 
             logger.info(`${clientName} => ${request.method} ${request.url}`);
-            
+
             try {
                 const simplifiedRequest = await httpRequest.createFrom(request);
                 logger.debug('%s => %s', clientName, JSON.stringify(simplifiedRequest));

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -125,6 +125,14 @@ module.exports = function (createBaseServer) {
 
             try {
                 const simplifiedRequest = await httpRequest.createFrom(request);
+                let logMessage = `${clientName} => ${request.method} ${request.url}`;
+                
+                // Add request body to log if it exists
+                if (simplifiedRequest.body && Object.keys(simplifiedRequest.body).length > 0) {
+                    logMessage += ` body: ${JSON.stringify(simplifiedRequest.body)}`;
+                }
+                
+                logger.info(logMessage);
                 logger.debug('%s => %s', clientName, JSON.stringify(simplifiedRequest));
 
                 const mbResponse = await responseFn(simplifiedRequest, { rawUrl: request.url }),

--- a/src/models/http/baseHttpServer.js
+++ b/src/models/http/baseHttpServer.js
@@ -121,16 +121,10 @@ module.exports = function (createBaseServer) {
         server.on('request', async (request, response) => {
             const clientName = helpers.socketName(request.socket);
 
+            logger.info(`${clientName} => ${request.method} ${request.url}`);
+            
             try {
                 const simplifiedRequest = await httpRequest.createFrom(request);
-                let logMessage = `${clientName} => ${request.method} ${request.url}`;
-                
-                // Add request body to log if it exists
-                if (simplifiedRequest.body && Object.keys(simplifiedRequest.body).length > 0) {
-                    logMessage += ` body: ${JSON.stringify(simplifiedRequest.body)}`;
-                }
-                
-                logger.info(logMessage);
                 logger.debug('%s => %s', clientName, JSON.stringify(simplifiedRequest));
 
                 const mbResponse = await responseFn(simplifiedRequest, { rawUrl: request.url }),

--- a/src/views/imposter.ejs
+++ b/src/views/imposter.ejs
@@ -5,7 +5,7 @@ description = 'Information about a specific mountebank imposter'
 
 <%- include('_header') -%>
 
-<h1><%= imposter.protocol %> Imposter on port <%= imposter.port %></h1>
+<h1><% if (imposter.name) { %><%= imposter.name %> - <% } %><%= imposter.protocol %> Imposter on port <%= imposter.port %></h1>
 
 <h2>Requests</h2>
 

--- a/src/views/imposter.ejs
+++ b/src/views/imposter.ejs
@@ -5,7 +5,7 @@ description = 'Information about a specific mountebank imposter'
 
 <%- include('_header') -%>
 
-<h1><% if (imposter.name) { %><%= imposter.name %> - <% } %><%= imposter.protocol %> Imposter on port <%= imposter.port %></h1>
+<h1><%= imposter.protocol %> Imposter on port <%= imposter.port %></h1>
 
 <h2>Requests</h2>
 


### PR DESCRIPTION
  Problem

  HTTP Imposter detail pages (/imposters/{port}) only displayed generic titles like "http Imposter on port 5034". This made it difficult for users to immediately identify which service/API was running on that port.

  Solution

  Enhanced the imposter detail page to display the imposter's name field in the title when available, providing better service identification.

  Results

  - With name: "E-Commerce API - http Imposter on port 5034"
  - Without name: "http Imposter on port 5034" (unchanged behavior)

  Benefits

  1. Improved User Experience: Service identity is immediately clear
  2. Backward Compatibility: Existing imposters without names are unaffected

  Test Examples

  Named imposter
```
  {
    "name": "User Management API",
    "port": 3000,
    "protocol": "http"
  }
```
  Result: "User Management API - http Imposter on port 3000"

  Unnamed imposter (existing behavior)
```
  {
    "port": 4000,
    "protocol": "http"
  }
```
  Result: "http Imposter on port 4000" (no change)

  This enhancement is particularly valuable for teams running multiple imposters simultaneously!